### PR TITLE
feat(i18n): 添加国际化支持，更新邮件发送功能和错误处理

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,7 @@ logs:
 
 database:
   # 数据库类型 mysql sqlite3
-  driver: mysql
+  driver: sqlite3
   # 数据库连接sqlite3数据文件的路径
   source: data/go-ldap-admin.db
 
@@ -68,6 +68,17 @@ rate-limit:
   fill-interval: 50
   # 桶容量
   capacity: 200
+
+i18n:
+  # 默认语言
+  default-locale: zh-CN
+  # 支持语言列表
+  supported-locales:
+    - zh-CN
+    - en-US
+    - ja-JP
+    - es-ES
+    - ko-KR
 
 # email configuration
 email:

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type config struct {
 	// Casbin    *CasbinConfig    `mapstructure:"casbin" json:"casbin"`
 	Jwt       *JwtConfig       `mapstructure:"jwt" json:"jwt"`
 	RateLimit *RateLimitConfig `mapstructure:"rate-limit" json:"rateLimit"`
+	I18n      *I18nConfig      `mapstructure:"i18n" json:"i18n"`
 	Ldap      *LdapConfig      `mapstructure:"ldap" json:"ldap"`
 	Email     *EmailConfig     `mapstructure:"email" json:"email"`
 	DingTalk  *DingTalkConfig  `mapstructure:"dingtalk" json:"dingTalk"`
@@ -57,6 +58,7 @@ func InitConfig() {
 		if err := viper.Unmarshal(Conf); err != nil {
 			panic(fmt.Errorf("初始化配置文件失败:%s", err))
 		}
+		normalizeConfig()
 		// 读取rsa key
 		Conf.System.RSAPublicBytes = pub
 		Conf.System.RSAPrivateBytes = priv
@@ -69,6 +71,7 @@ func InitConfig() {
 	if err := viper.Unmarshal(Conf); err != nil {
 		panic(fmt.Errorf("初始化配置文件失败:%s", err))
 	}
+	normalizeConfig()
 	// 读取rsa key
 	Conf.System.RSAPublicBytes = pub
 	Conf.System.RSAPrivateBytes = priv
@@ -134,6 +137,18 @@ func InitConfig() {
 	}
 }
 
+func normalizeConfig() {
+	if Conf.I18n == nil {
+		Conf.I18n = &I18nConfig{}
+	}
+	if Conf.I18n.DefaultLocale == "" {
+		Conf.I18n.DefaultLocale = "zh-CN"
+	}
+	if len(Conf.I18n.SupportedLocales) == 0 {
+		Conf.I18n.SupportedLocales = []string{"zh-CN", "en-US", "ja-JP", "es-ES", "ko-KR"}
+	}
+}
+
 type SystemConfig struct {
 	Mode            string `mapstructure:"mode" json:"mode"`
 	UrlPathPrefix   string `mapstructure:"url-path-prefix" json:"urlPathPrefix"`
@@ -184,6 +199,11 @@ type JwtConfig struct {
 type RateLimitConfig struct {
 	FillInterval int64 `mapstructure:"fill-interval" json:"fillInterval"`
 	Capacity     int64 `mapstructure:"capacity" json:"capacity"`
+}
+
+type I18nConfig struct {
+	DefaultLocale    string   `mapstructure:"default-locale" json:"defaultLocale"`
+	SupportedLocales []string `mapstructure:"supported-locales" json:"supportedLocales"`
 }
 
 type LdapConfig struct {

--- a/controller/a_controller.go
+++ b/controller/a_controller.go
@@ -3,15 +3,13 @@ package controller
 import (
 	"fmt"
 	"net/http"
-	"regexp"
 
+	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-playground/locales/zh"
-	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
-	zht "github.com/go-playground/validator/v10/translations/zh"
 )
 
 var (
@@ -23,23 +21,7 @@ var (
 	OperationLog  = &OperationLogController{}
 	Base          = &BaseController{}
 	FieldRelation = &FieldRelationController{}
-
-	validate = validator.New()
-	trans    ut.Translator
 )
-
-func init() {
-	uni := ut.New(zh.New())
-	trans, _ = uni.GetTranslator("zh")
-	_ = zht.RegisterDefaultTranslations(validate, trans)
-	_ = validate.RegisterValidation("checkMobile", checkMobile)
-}
-
-func checkMobile(fl validator.FieldLevel) bool {
-	reg := `1\d{10}`
-	rgx := regexp.MustCompile(reg)
-	return rgx.MatchString(fl.Field().String())
-}
 
 func Run(c *gin.Context, req any, fn func() (any, any)) {
 	var err error
@@ -50,8 +32,9 @@ func Run(c *gin.Context, req any, fn func() (any, any)) {
 		return
 	}
 	// 校验
-	err = validate.Struct(req)
+	err = common.Validate.Struct(req)
 	if err != nil {
+		trans := common.TranslatorForLocale(i18n.LocaleFromContext(c))
 		for _, err := range err.(validator.ValidationErrors) {
 			tools.Err(c, tools.NewValidatorError(fmt.Errorf("%s", err.Translate(trans))), nil)
 			return

--- a/locales/en-US.yaml
+++ b/locales/en-US.yaml
@@ -1,0 +1,411 @@
+common:
+  success: success
+  unknown_error: unknown error
+  request_invalid: invalid request
+error:
+  database: database operation failed
+  ldap: LDAP operation failed
+  operation: operation failed
+  validator: validation failed
+auth:
+  login_success: login successful
+  logout_success: logout successful
+  refresh_success: token refreshed successfully
+  jwt_failed: "JWT authentication failed, code: {code}, message: {message}"
+  not_logged_in: user is not logged in
+  user_not_found: user does not exist
+  user_disabled: the current user has been disabled
+  password_incorrect: incorrect password
+  no_permission: no permission
+rate_limit:
+  limited: too many requests
+email:
+  password_reset_subject: LDAP password reset successful
+  password_reset_body: "<li><a>Your new password is: %s </a></li>"
+  verification_code_subject: Verification code - password reset
+  verification_code_body: "<div><div>Hello,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>Your verification code is %s. For account security, this code is valid for 5 minutes. Confirm that this was your own operation and do not share it with anyone.</p></div><div><p>This is a system email. Please do not reply.</p></div></div>"
+  user_creation_subject: LDAP account created successfully
+  user_creation_body: "<div><div>Hello %s,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>Your LDAP account has been created. Account information:</p><ul><li>Username: %s</li><li>Nickname: %s</li><li>Initial password: %s</li></ul><p style=\"color: #ff6600;\">Keep your account information safe and change your password after first login.</p></div><div><p>This is a system email. Please do not reply.</p></div></div>"
+  admin_password_reset_subject: LDAP password reset notification
+  admin_password_reset_body: "<div><div>Hello %s,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>Your LDAP account password has been reset. New password information:</p><ul><li>Username: %s</li><li>New password: %s</li></ul><p style=\"color: #ff6600;\">For account security, please log in and change it as soon as possible.</p><p style=\"color: #ff0000;\">Keep your account information safe and do not share it with anyone.</p></div><div><p>This is a system email. Please do not reply.</p></div></div>"
+dashboard:
+  user: users
+  group: groups
+  role: roles
+  menu: menus
+  api: APIs
+  log: logs
+sync:
+  dept_list_failed: "failed to get {provider} department list: {error}"
+  dept_convert_failed: "failed to convert {provider} department data: {error}"
+  empty_depts: got 0 departments
+  dept_add_failed: "failed to add department [{dept}]: {error}"
+  child_dept_add_failed: "failed to add child department: {error}"
+  parent_dept_query_failed: "failed to query parent department: {error}"
+  add_dept_failed: "failed to add department {dept}: {error}"
+  user_list_failed: "failed to get {provider} user list: {error}"
+  user_convert_failed: "failed to convert {provider} user data: {error}"
+  empty_users: got 0 users
+  user_write_failed: "failed to write user [{username}]: {error}"
+  leave_user_list_failed: "failed to get {provider} departed user list: {error}"
+  leave_user_query_failed: "failed to query departed user [{username}] in MySQL: {error}"
+  leave_user_ldap_delete_failed: "failed to delete departed user [{username}] in LDAP: {error}"
+  leave_user_status_update_failed: "failed to update departed user [{username}] status in MySQL: {error}"
+  role_info_failed: "failed to get role information by role ID: {error}"
+  add_user_failed: "failed to add user {username}: {error}"
+  mysql_user_list_failed: "failed to get MySQL user list: {error}"
+  dept_ids_convert_failed: "failed to convert department IDs to internal department IDs: {error}"
+  user_dept_ids_convert_failed: "failed to convert department IDs for user [{username}] to internal department IDs: {error}"
+  user_role_info_failed: "failed to get role information for user [{username}]: {error}"
+common_user:
+  mysql_create_failed: "failed to create user in MySQL: {error}"
+  ldap_create_failed: "failed to create user in LDAP: {error}"
+  mysql_add_group_relation_failed: "failed to add user-group relation in MySQL: {error}"
+  ldap_add_group_relation_failed: "failed to add user-group relation in LDAP: {error}"
+  ldap_update_failed: "failed to update user in LDAP: {error}"
+  mysql_update_failed: "failed to update user in MySQL: {error}"
+  mysql_remove_group_relation_failed: "failed to remove user from group in MySQL: {error}"
+  ldap_remove_group_relation_failed: "failed to remove user from group in LDAP: {error}"
+base:
+  email_not_found: email does not exist, please check the email address
+  code_expired: the verification code expired after 5 minutes, please reset the password again
+  code_invalid: the verification code is incorrect, please use the latest code sent to your email
+  reset_password_user_unavailable: this user has left or has not been synced to LDAP, please contact an administrator
+  send_email_failed: "failed to send email: {error}"
+  email_query_failed: "failed to query user by email: {error}"
+  ldap_new_password_failed: "failed to generate new password in LDAP: {error}"
+user:
+  username_exists: username already exists, do not add it again
+  mobile_exists: mobile number already exists, do not add it again
+  job_number_exists: job number already exists, do not add it again
+  mail_exists: email already exists, do not add it again
+  password_encrypt_failed: failed to encrypt password
+  password_decrypt_failed: failed to decrypt password
+  password_min_length: password must be at least {min} characters
+  cannot_delete_self: users cannot delete themselves
+  not_found: user does not exist
+  current_min_role_sort_failed: failed to get current user's minimum role sort
+  role_info_failed: failed to get role information by role ID
+  cannot_create_higher_or_equal: users cannot create users with a higher or equal role level than themselves
+  department_info_failed: "failed to get department information by department ID: {error}"
+  create_failed: "failed to add user: {error}"
+  list_failed: "failed to get user list: {error}"
+  count_failed: "failed to get user count: {error}"
+  cannot_change_self_role: cannot change your own role
+  min_role_sort_by_id_failed: failed to get user minimum role sort by user ID
+  cannot_update_higher_or_equal: users cannot update users with a higher or equal role level than themselves
+  update_failed: "failed to update user: {error}"
+  cannot_delete_higher: users cannot delete users with a higher role level than themselves
+  info_failed: "failed to get user information: {error}"
+  ldap_delete_failed: "failed to delete user in LDAP: {error}"
+  mysql_delete_failed: "failed to delete user in MySQL: {error}"
+  ldap_password_update_failed: "failed to update password in LDAP: {error}"
+  mysql_password_update_failed: "failed to update password in MySQL: {error}"
+  mysql_query_failed: "failed to query user in MySQL: {error}"
+  ldap_add_failed: "failed to add user in LDAP: {error}"
+  mysql_status_update_failed: "failed to update user status in MySQL: {error}"
+  current_info_failed: "failed to get current user information: {error}"
+menu:
+  name_exists: menu name already exists
+  create_failed: "failed to create record: {error}"
+  update_failed: "failed to update record: {error}"
+  delete_failed: "failed to delete API: {error}"
+  record_not_found: no record exists for this ID
+  record_get_failed: "failed to get record: {error}"
+  count_failed: failed to get menu count
+api:
+  create_failed: "failed to create API: {error}"
+  list_failed: "failed to get API list: {error}"
+  count_failed: failed to get API count
+  not_found: API does not exist
+  update_failed: "failed to update API: {error}"
+  delete_failed: "failed to delete API: {error}"
+operation_log:
+  list_failed: "failed to get operation log list: {error}"
+  count_failed: failed to get operation log count
+  not_found: operation log record does not exist
+  delete_failed: "failed to delete operation log record: {error}"
+  clean_failed: "failed to clear operation logs: {error}"
+role:
+  name_exists: role name already exists
+  not_found: role does not exist
+  current_max_sort_failed: "failed to get current user's highest role level: {error}"
+  no_update_permission: current user has no permission to update roles
+  cannot_create_higher_or_equal: cannot create a role with a higher or equal level than yourself
+  create_failed: "failed to create role: {error}"
+  list_failed: "failed to get role list: {error}"
+  count_failed: failed to get role count
+  info_not_found: failed to get role information, no matching role found
+  cannot_update_higher_or_equal: cannot update a role with a higher or equal level than yourself
+  cannot_set_higher_or_equal: cannot set the role level higher than or equal to the current user's level
+  update_failed: "failed to update role: {error}"
+  keyword_policy_update_failed: role updated, but failed to update permission APIs linked to the role keyword
+  keyword_policy_load_failed: role updated, but failed to load permission API policies linked to the role keyword
+  no_role_info: failed to get role information
+  cannot_delete_higher_or_equal: cannot delete a role with a higher or equal level than yourself
+  delete_failed: "failed to delete role: {error}"
+  menu_list_failed: "failed to get role permission menus: {error}"
+  resource_failed: "failed to get resource: {error}"
+  cannot_update_higher_or_equal_permissions: cannot update permission menus for a role with a higher or equal level than yourself
+  current_user_menu_list_failed: "failed to get current user's accessible menu list: {error}"
+  no_menu_permission: "no permission to assign menu ID {id}"
+  menu_all_list_failed: "failed to get menu list: {error}"
+  update_menus_failed: "failed to update role permission menus: {error}"
+  api_info_failed: failed to get API information by API ID
+  no_api_permission: "no permission to assign API path {path}, method {method}"
+  update_apis_failed: failed to update role permission APIs
+group:
+  parent_info_failed: failed to get parent group information
+  dn_exists: the group DN already exists
+  ldap_create_failed: "failed to create group in LDAP: {error}"
+  mysql_create_failed: failed to create group in MySQL
+  add_user_failed: "failed to add user to group: {error}"
+  user_list_failed: "failed to get user list: {error}"
+  list_failed: "failed to get group list: {error}"
+  count_failed: failed to get group count
+  not_found: group does not exist
+  ldap_update_failed: "failed to update group in LDAP: {error}"
+  mysql_update_failed: failed to update group in MySQL
+  some_not_found: some groups do not exist
+  has_children: this group has child groups, delete child groups first
+  ldap_delete_failed: "failed to delete group in LDAP: {error}"
+  delete_failed: "failed to delete group: {error}"
+  get_failed: "failed to get group: {error}"
+  ou_cannot_add_user: OU groups cannot contain users
+  ou_has_no_user: OU groups have no users
+  ldap_add_user_failed: "failed to add user to group in LDAP: {error}"
+  user_department_failed: "failed to process user's department data: {error}"
+  mysql_user_update_failed: "failed to update user in MySQL: {error}"
+  ldap_remove_user_failed: "failed to remove user from LDAP: {error}"
+  mysql_remove_user_failed: "failed to remove user from MySQL: {error}"
+field_relation:
+  exists: the dynamic field relation for this platform already exists
+  not_found: the dynamic field relation for this platform does not exist
+  map_to_json_failed: "failed to convert map to JSON: {error}"
+  create_failed: "failed to create dynamic field relation: {error}"
+  list_failed: "failed to get dynamic field relation list: {error}"
+  update_failed: "failed to update dynamic field relation: {error}"
+  delete_failed: "failed to delete dynamic field relation: {error}"
+legacy:
+  common:
+    current_user_failed: failed to get current login user
+    resource_list_failed: "failed to get resource list: {error}"
+    record_not_found: record does not exist
+  user:
+    some_not_found: some users do not exist
+    not_found: user does not exist
+    old_password_incorrect: old password is incorrect
+    old_password_parse_failed: failed to parse old password
+    new_password_parse_failed: failed to parse new password
+    already_active: user is already active
+    already_inactive: user is already inactive
+    only_admin_change_status: only administrators can change user status
+    list_failed: "failed to get user list: {error}"
+    count_failed: failed to get user count
+    create_failed: "failed to add user: {error}"
+    update_failed: "failed to update user: {error}"
+    info_failed: "failed to get user information: {error}"
+    ldap_delete_failed: "failed to delete user in LDAP: {error}"
+    ldap_add_failed: "failed to add user in LDAP: {error}"
+    ldap_password_update_failed: "failed to update password in LDAP: {error}"
+    mysql_delete_failed: "failed to delete user in MySQL: {error}"
+    mysql_password_update_failed: "failed to update password in MySQL: {error}"
+    mysql_status_update_failed: "failed to update user status in MySQL: {error}"
+  api:
+    create_failed: "failed to create API: {error}"
+    list_failed: "failed to get API list: {error}"
+    count_failed: failed to get API count
+    not_found: API does not exist
+    update_failed: "failed to update API: {error}"
+    delete_failed: "failed to delete API: {error}"
+  role:
+    name_exists: role name already exists
+    not_found: role does not exist
+    current_max_sort_failed: "failed to get current user's highest role level: {error}"
+    no_update_permission: current user has no permission to update roles
+    cannot_create_higher_or_equal: cannot create a role with a higher or equal level than yourself
+    create_failed: "failed to create role: {error}"
+    list_failed: "failed to get role list: {error}"
+    info_failed: "failed to get role information: {error}"
+    cannot_update_higher_or_equal: cannot update a role with a higher or equal level than yourself
+    cannot_set_higher_or_equal: cannot set the role level higher than or equal to the current user's level
+    update_failed: "failed to update role: {error}"
+    no_role_info: failed to get role information
+    cannot_delete_higher_or_equal: cannot delete a role with a higher or equal level than yourself
+    delete_failed: "failed to delete role: {error}"
+    menu_list_failed: "failed to get role permission menus: {error}"
+    count_failed: failed to get role count
+  group:
+    parent_info_failed: failed to get parent group information
+    dn_exists: the group DN already exists
+    ldap_create_failed: "failed to create group in LDAP: {error}"
+    mysql_create_failed: failed to create group in MySQL
+    add_user_failed: "failed to add user to group: {error}"
+    list_failed: "failed to get group list: {error}"
+    count_failed: failed to get group count
+    not_found: group does not exist
+    ldap_update_failed: "failed to update group in LDAP: {error}"
+    mysql_update_failed: failed to update group in MySQL
+    some_not_found: some groups do not exist
+    has_children: this group has child groups, delete child groups first
+    ldap_delete_failed: "failed to delete group in LDAP: {error}"
+    get_failed: "failed to get group: {error}"
+    ou_cannot_add_user: OU groups cannot contain users
+    ou_has_no_user: OU groups have no users
+    ldap_add_user_failed: "failed to add user to group in LDAP: {error}"
+    user_department_failed: "failed to process user's department data: {error}"
+    mysql_user_update_failed: "failed to update user in MySQL: {error}"
+    ldap_remove_user_failed: "failed to remove user from LDAP: {error}"
+    mysql_remove_user_failed: "failed to remove user from MySQL: {error}"
+  base:
+    email_query_failed: "failed to query user by email: {error}"
+    ldap_new_password_failed: "failed to generate new LDAP password: {error}"
+  menu:
+    count_failed: failed to get menu count
+  log:
+    count_failed: failed to get log count
+builtin:
+  creator:
+    系统: System
+    system: System
+  role:
+    admin:
+      name: Administrator
+      remark: ""
+    user:
+      name: Standard user
+      remark: ""
+    guest:
+      name: Guest
+      remark: ""
+  menu:
+    UserManage:
+      name: Personnel
+      title: Personnel
+    User:
+      name: Users
+      title: Users
+    Group:
+      name: Groups
+      title: Groups
+    FieldRelation:
+      name: Field Relations
+      title: Field Relations
+    System:
+      name: System
+      title: System
+    Role:
+      name: Roles
+      title: Roles
+    Menu:
+      name: Menus
+      title: Menus
+    Api:
+      name: APIs
+      title: APIs
+    Log:
+      name: Logs
+      title: Logs
+    OperationLog:
+      name: Operation Logs
+      title: Operation Logs
+  api:
+    category:
+      base: Base
+      user: Users
+      group: Groups
+      role: Roles
+      menu: Menus
+      api: APIs
+      fieldrelation: Field Relations
+      log: Logs
+    remark:
+      get:
+        base_ping: Health check
+        base_encryptpwd: Encrypt password
+        base_decryptpwd: Decrypt password
+        base_config: Get system config
+        base_version: Get system version
+        base_dashboard: Get dashboard data
+        user_info: Get current user info
+        user_list: Get user list
+        group_list: Get group list
+        group_tree: Get group tree
+        group_useringroup: Get users in group
+        group_usernoingroup: Get users not in group
+        role_list: Get role list
+        role_getmenulist: Get role permission menus
+        role_getapilist: Get role permission APIs
+        menu_tree: Get menu tree
+        menu_access_tree: Get user menu tree
+        api_list: Get API list
+        api_tree: Get API tree
+        fieldrelation_list: Get dynamic field relation list
+        log_operation_list: Get operation log list
+      post:
+        base_login: User login
+        base_logout: User logout
+        base_refreshtoken: Refresh JWT token
+        base_sendcode: Send verification code to user email
+        base_changepwd: Change password by email
+        user_changepwd: Change user login password
+        user_resetpassword: Reset user password
+        user_add: Create user
+        user_update: Update user
+        user_delete: Batch delete users
+        user_changeuserstatus: Change user employment status
+        user_syncdingtalkusers: Sync users from DingTalk
+        user_syncwecomusers: Sync users from WeCom
+        user_syncfeishuusers: Sync users from Feishu
+        user_syncopenldapusers: Sync users from OpenLDAP
+        user_syncsqlusers: Sync database users to LDAP
+        group_add: Create group
+        group_update: Update group
+        group_delete: Batch delete groups
+        group_adduser: Add users to group
+        group_removeuser: Remove users from group
+        group_syncdingtalkdepts: Sync departments from DingTalk
+        group_syncwecomdepts: Sync departments from WeCom
+        group_syncfeishudepts: Sync departments from Feishu
+        group_syncopenldapdepts: Sync departments from OpenLDAP
+        group_syncsqlgroups: Sync database groups to LDAP
+        role_add: Create role
+        role_update: Update role
+        role_updatemenus: Update role permission menus
+        role_updateapis: Update role permission APIs
+        role_delete: Batch delete roles
+        menu_add: Create menu
+        menu_update: Update menu
+        menu_delete: Batch delete menus
+        api_add: Create API
+        api_update: Update API
+        api_delete: Batch delete APIs
+        fieldrelation_add: Create dynamic field relation
+        fieldrelation_update: Update dynamic field relation
+        fieldrelation_delete: Batch delete dynamic field relations
+        log_operation_delete: Batch delete operation logs
+      delete:
+        log_operation_clean: Clear operation logs
+  group:
+    name:
+      openldap:
+        root: root
+      dingtalk:
+        dingtalkroot: DingTalk root department
+      wecom:
+        wecomroot: WeCom root department
+      feishu:
+        feishuroot: Feishu root department
+      platform:
+        group: Default group
+    remark:
+      openldap:
+        root: Base
+      dingtalk:
+        dingtalkroot: DingTalk root department
+      wecom:
+        wecomroot: WeCom root department
+      feishu:
+        feishuroot: Feishu root department
+      platform:
+        group: Default group

--- a/locales/es-ES.yaml
+++ b/locales/es-ES.yaml
@@ -1,0 +1,411 @@
+common:
+  success: correcto
+  unknown_error: error desconocido
+  request_invalid: solicitud no válida
+error:
+  database: operación de base de datos fallida
+  ldap: operación LDAP fallida
+  operation: operación fallida
+  validator: validación fallida
+auth:
+  login_success: inicio de sesión correcto
+  logout_success: sesión cerrada correctamente
+  refresh_success: token actualizado correctamente
+  jwt_failed: "falló la autenticación JWT, código: {code}, mensaje: {message}"
+  not_logged_in: el usuario no ha iniciado sesión
+  user_not_found: el usuario no existe
+  user_disabled: el usuario actual está deshabilitado
+  password_incorrect: contraseña incorrecta
+  no_permission: sin permisos
+rate_limit:
+  limited: demasiadas solicitudes
+email:
+  password_reset_subject: Restablecimiento de contraseña LDAP completado
+  password_reset_body: "<li><a>Tu nueva contraseña es: %s </a></li>"
+  verification_code_subject: Código de verificación - restablecimiento de contraseña
+  verification_code_body: "<div><div>Hola,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>Tu código de verificación es %s. Por seguridad de la cuenta, el código es válido durante 5 minutos. Confirma que esta operación fue realizada por ti y no lo compartas con nadie.</p></div><div><p>Este es un correo del sistema. No respondas.</p></div></div>"
+  user_creation_subject: Cuenta LDAP creada correctamente
+  user_creation_body: "<div><div>Hola %s,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>Tu cuenta LDAP ha sido creada. Información de la cuenta:</p><ul><li>Usuario: %s</li><li>Nombre: %s</li><li>Contraseña inicial: %s</li></ul><p style=\"color: #ff6600;\">Guarda la información de la cuenta de forma segura y cambia la contraseña después del primer inicio de sesión.</p></div><div><p>Este es un correo del sistema. No respondas.</p></div></div>"
+  admin_password_reset_subject: Notificación de restablecimiento de contraseña LDAP
+  admin_password_reset_body: "<div><div>Hola %s,</div><div style=\"padding: 8px 40px 8px 50px;\"><p>La contraseña de tu cuenta LDAP ha sido restablecida. Nueva información de contraseña:</p><ul><li>Usuario: %s</li><li>Nueva contraseña: %s</li></ul><p style=\"color: #ff6600;\">Por seguridad, inicia sesión y cámbiala lo antes posible.</p><p style=\"color: #ff0000;\">Guarda la información de la cuenta de forma segura y no la compartas con nadie.</p></div><div><p>Este es un correo del sistema. No respondas.</p></div></div>"
+dashboard:
+  user: usuarios
+  group: grupos
+  role: roles
+  menu: menús
+  api: APIs
+  log: registros
+sync:
+  dept_list_failed: "no se pudo obtener la lista de departamentos de {provider}: {error}"
+  dept_convert_failed: "no se pudieron convertir los datos de departamentos de {provider}: {error}"
+  empty_depts: se obtuvieron 0 departamentos
+  dept_add_failed: "no se pudo agregar el departamento [{dept}]: {error}"
+  child_dept_add_failed: "no se pudo agregar el departamento hijo: {error}"
+  parent_dept_query_failed: "no se pudo consultar el departamento padre: {error}"
+  add_dept_failed: "no se pudo agregar el departamento {dept}: {error}"
+  user_list_failed: "no se pudo obtener la lista de usuarios de {provider}: {error}"
+  user_convert_failed: "no se pudieron convertir los datos de usuarios de {provider}: {error}"
+  empty_users: se obtuvieron 0 usuarios
+  user_write_failed: "no se pudo escribir el usuario [{username}]: {error}"
+  leave_user_list_failed: "no se pudo obtener la lista de usuarios dados de baja de {provider}: {error}"
+  leave_user_query_failed: "no se pudo consultar en MySQL el usuario dado de baja [{username}]: {error}"
+  leave_user_ldap_delete_failed: "no se pudo eliminar en LDAP el usuario dado de baja [{username}]: {error}"
+  leave_user_status_update_failed: "no se pudo actualizar en MySQL el estado del usuario dado de baja [{username}]: {error}"
+  role_info_failed: "no se pudo obtener la información del rol por ID: {error}"
+  add_user_failed: "no se pudo agregar el usuario {username}: {error}"
+  mysql_user_list_failed: "no se pudo obtener la lista de usuarios de MySQL: {error}"
+  dept_ids_convert_failed: "no se pudieron convertir los IDs de departamento a IDs internos: {error}"
+  user_dept_ids_convert_failed: "no se pudieron convertir los IDs de departamento del usuario [{username}] a IDs internos: {error}"
+  user_role_info_failed: "no se pudo obtener la información de roles del usuario [{username}]: {error}"
+common_user:
+  mysql_create_failed: "no se pudo crear el usuario en MySQL: {error}"
+  ldap_create_failed: "no se pudo crear el usuario en LDAP: {error}"
+  mysql_add_group_relation_failed: "no se pudo agregar la relación usuario-grupo en MySQL: {error}"
+  ldap_add_group_relation_failed: "no se pudo agregar la relación usuario-grupo en LDAP: {error}"
+  ldap_update_failed: "no se pudo actualizar el usuario en LDAP: {error}"
+  mysql_update_failed: "no se pudo actualizar el usuario en MySQL: {error}"
+  mysql_remove_group_relation_failed: "no se pudo quitar el usuario del grupo en MySQL: {error}"
+  ldap_remove_group_relation_failed: "no se pudo quitar el usuario del grupo en LDAP: {error}"
+base:
+  email_not_found: el correo no existe, comprueba que sea correcto
+  code_expired: el código de verificación expiró después de 5 minutos, restablece la contraseña otra vez
+  code_invalid: el código de verificación es incorrecto, usa el último código enviado a tu correo
+  reset_password_user_unavailable: este usuario salió de la organización o no se sincronizó con LDAP, contacta con un administrador
+  send_email_failed: "no se pudo enviar el correo: {error}"
+  email_query_failed: "no se pudo consultar el usuario por correo: {error}"
+  ldap_new_password_failed: "no se pudo generar una nueva contraseña en LDAP: {error}"
+user:
+  username_exists: el nombre de usuario ya existe, no lo agregues de nuevo
+  mobile_exists: el número de móvil ya existe, no lo agregues de nuevo
+  job_number_exists: el número de empleado ya existe, no lo agregues de nuevo
+  mail_exists: el correo ya existe, no lo agregues de nuevo
+  password_encrypt_failed: no se pudo cifrar la contraseña
+  password_decrypt_failed: no se pudo descifrar la contraseña
+  password_min_length: la contraseña debe tener al menos {min} caracteres
+  cannot_delete_self: los usuarios no pueden eliminarse a sí mismos
+  not_found: el usuario no existe
+  current_min_role_sort_failed: no se pudo obtener el nivel mínimo de rol del usuario actual
+  role_info_failed: no se pudo obtener la información del rol por ID
+  cannot_create_higher_or_equal: no puedes crear usuarios con un nivel de rol superior o igual al tuyo
+  department_info_failed: "no se pudo obtener la información del departamento por ID: {error}"
+  create_failed: "no se pudo agregar el usuario: {error}"
+  list_failed: "no se pudo obtener la lista de usuarios: {error}"
+  count_failed: "no se pudo obtener el total de usuarios: {error}"
+  cannot_change_self_role: no puedes cambiar tu propio rol
+  min_role_sort_by_id_failed: no se pudo obtener el nivel mínimo de rol por ID de usuario
+  cannot_update_higher_or_equal: no puedes actualizar usuarios con un nivel de rol superior o igual al tuyo
+  update_failed: "no se pudo actualizar el usuario: {error}"
+  cannot_delete_higher: no puedes eliminar usuarios con un nivel de rol superior al tuyo
+  info_failed: "no se pudo obtener la información del usuario: {error}"
+  ldap_delete_failed: "no se pudo eliminar el usuario en LDAP: {error}"
+  mysql_delete_failed: "no se pudo eliminar el usuario en MySQL: {error}"
+  ldap_password_update_failed: "no se pudo actualizar la contraseña en LDAP: {error}"
+  mysql_password_update_failed: "no se pudo actualizar la contraseña en MySQL: {error}"
+  mysql_query_failed: "no se pudo consultar el usuario en MySQL: {error}"
+  ldap_add_failed: "no se pudo agregar el usuario en LDAP: {error}"
+  mysql_status_update_failed: "no se pudo actualizar el estado del usuario en MySQL: {error}"
+  current_info_failed: "no se pudo obtener la información del usuario actual: {error}"
+menu:
+  name_exists: el nombre del menú ya existe
+  create_failed: "no se pudo crear el registro: {error}"
+  update_failed: "no se pudo actualizar el registro: {error}"
+  delete_failed: "no se pudo eliminar la API: {error}"
+  record_not_found: no existe ningún registro para este ID
+  record_get_failed: "no se pudo obtener el registro: {error}"
+  count_failed: no se pudo obtener el total de menús
+api:
+  create_failed: "no se pudo crear la API: {error}"
+  list_failed: "no se pudo obtener la lista de APIs: {error}"
+  count_failed: no se pudo obtener el total de APIs
+  not_found: la API no existe
+  update_failed: "no se pudo actualizar la API: {error}"
+  delete_failed: "no se pudo eliminar la API: {error}"
+operation_log:
+  list_failed: "no se pudo obtener la lista de registros de operación: {error}"
+  count_failed: no se pudo obtener el total de registros de operación
+  not_found: el registro de operación no existe
+  delete_failed: "no se pudo eliminar el registro de operación: {error}"
+  clean_failed: "no se pudieron vaciar los registros de operación: {error}"
+role:
+  name_exists: el nombre del rol ya existe
+  not_found: el rol no existe
+  current_max_sort_failed: "no se pudo obtener el nivel de rol más alto del usuario actual: {error}"
+  no_update_permission: el usuario actual no tiene permiso para actualizar roles
+  cannot_create_higher_or_equal: no se puede crear un rol con nivel superior o igual al propio
+  create_failed: "no se pudo crear el rol: {error}"
+  list_failed: "no se pudo obtener la lista de roles: {error}"
+  count_failed: no se pudo obtener el total de roles
+  info_not_found: no se pudo obtener la información del rol, no se encontró un rol coincidente
+  cannot_update_higher_or_equal: no se puede actualizar un rol con nivel superior o igual al propio
+  cannot_set_higher_or_equal: no se puede establecer el nivel del rol superior o igual al del usuario actual
+  update_failed: "no se pudo actualizar el rol: {error}"
+  keyword_policy_update_failed: el rol se actualizó, pero no se pudieron actualizar las APIs de permiso vinculadas a la clave del rol
+  keyword_policy_load_failed: el rol se actualizó, pero no se pudieron cargar las políticas de APIs vinculadas a la clave del rol
+  no_role_info: no se pudo obtener la información del rol
+  cannot_delete_higher_or_equal: no se puede eliminar un rol con nivel superior o igual al propio
+  delete_failed: "no se pudo eliminar el rol: {error}"
+  menu_list_failed: "no se pudieron obtener los menús de permiso del rol: {error}"
+  resource_failed: "no se pudo obtener el recurso: {error}"
+  cannot_update_higher_or_equal_permissions: no se pueden actualizar menús de permiso de un rol con nivel superior o igual al propio
+  current_user_menu_list_failed: "no se pudo obtener la lista de menús accesibles del usuario actual: {error}"
+  no_menu_permission: "sin permiso para asignar el menú con ID {id}"
+  menu_all_list_failed: "no se pudo obtener la lista de menús: {error}"
+  update_menus_failed: "no se pudieron actualizar los menús de permiso del rol: {error}"
+  api_info_failed: no se pudo obtener la información de la API por ID
+  no_api_permission: "sin permiso para asignar la API con ruta {path}, método {method}"
+  update_apis_failed: no se pudieron actualizar las APIs de permiso del rol
+group:
+  parent_info_failed: no se pudo obtener la información del grupo padre
+  dn_exists: el DN del grupo ya existe
+  ldap_create_failed: "no se pudo crear el grupo en LDAP: {error}"
+  mysql_create_failed: no se pudo crear el grupo en MySQL
+  add_user_failed: "no se pudo agregar el usuario al grupo: {error}"
+  user_list_failed: "no se pudo obtener la lista de usuarios: {error}"
+  list_failed: "no se pudo obtener la lista de grupos: {error}"
+  count_failed: no se pudo obtener el total de grupos
+  not_found: el grupo no existe
+  ldap_update_failed: "no se pudo actualizar el grupo en LDAP: {error}"
+  mysql_update_failed: no se pudo actualizar el grupo en MySQL
+  some_not_found: algunos grupos no existen
+  has_children: este grupo tiene subgrupos, elimina primero los subgrupos
+  ldap_delete_failed: "no se pudo eliminar el grupo en LDAP: {error}"
+  delete_failed: "no se pudo eliminar el grupo: {error}"
+  get_failed: "no se pudo obtener el grupo: {error}"
+  ou_cannot_add_user: los grupos OU no pueden contener usuarios
+  ou_has_no_user: los grupos OU no tienen usuarios
+  ldap_add_user_failed: "no se pudo agregar el usuario al grupo en LDAP: {error}"
+  user_department_failed: "no se pudo procesar los datos de departamento del usuario: {error}"
+  mysql_user_update_failed: "no se pudo actualizar el usuario en MySQL: {error}"
+  ldap_remove_user_failed: "no se pudo quitar el usuario de LDAP: {error}"
+  mysql_remove_user_failed: "no se pudo quitar el usuario de MySQL: {error}"
+field_relation:
+  exists: la relación dinámica de campos para esta plataforma ya existe
+  not_found: la relación dinámica de campos para esta plataforma no existe
+  map_to_json_failed: "no se pudo convertir el mapa a JSON: {error}"
+  create_failed: "no se pudo crear la relación dinámica de campos: {error}"
+  list_failed: "no se pudo obtener la lista de relaciones dinámicas de campos: {error}"
+  update_failed: "no se pudo actualizar la relación dinámica de campos: {error}"
+  delete_failed: "no se pudo eliminar la relación dinámica de campos: {error}"
+legacy:
+  common:
+    current_user_failed: no se pudo obtener el usuario actual
+    resource_list_failed: "no se pudo obtener la lista de recursos: {error}"
+    record_not_found: el registro no existe
+  user:
+    some_not_found: algunos usuarios no existen
+    not_found: el usuario no existe
+    old_password_incorrect: la contraseña actual es incorrecta
+    old_password_parse_failed: no se pudo analizar la contraseña actual
+    new_password_parse_failed: no se pudo analizar la contraseña nueva
+    already_active: el usuario ya está activo
+    already_inactive: el usuario ya está inactivo
+    only_admin_change_status: solo los administradores pueden cambiar el estado del usuario
+    list_failed: "no se pudo obtener la lista de usuarios: {error}"
+    count_failed: no se pudo obtener el total de usuarios
+    create_failed: "no se pudo agregar el usuario: {error}"
+    update_failed: "no se pudo actualizar el usuario: {error}"
+    info_failed: "no se pudo obtener la información del usuario: {error}"
+    ldap_delete_failed: "no se pudo eliminar el usuario en LDAP: {error}"
+    ldap_add_failed: "no se pudo agregar el usuario en LDAP: {error}"
+    ldap_password_update_failed: "no se pudo actualizar la contraseña en LDAP: {error}"
+    mysql_delete_failed: "no se pudo eliminar el usuario en MySQL: {error}"
+    mysql_password_update_failed: "no se pudo actualizar la contraseña en MySQL: {error}"
+    mysql_status_update_failed: "no se pudo actualizar el estado del usuario en MySQL: {error}"
+  api:
+    create_failed: "no se pudo crear la API: {error}"
+    list_failed: "no se pudo obtener la lista de APIs: {error}"
+    count_failed: no se pudo obtener el total de APIs
+    not_found: la API no existe
+    update_failed: "no se pudo actualizar la API: {error}"
+    delete_failed: "no se pudo eliminar la API: {error}"
+  role:
+    name_exists: el nombre del rol ya existe
+    not_found: el rol no existe
+    current_max_sort_failed: "no se pudo obtener el nivel de rol más alto del usuario actual: {error}"
+    no_update_permission: el usuario actual no tiene permiso para actualizar roles
+    cannot_create_higher_or_equal: no puedes crear un rol de nivel mayor o igual al tuyo
+    create_failed: "no se pudo crear el rol: {error}"
+    list_failed: "no se pudo obtener la lista de roles: {error}"
+    info_failed: "no se pudo obtener la información del rol: {error}"
+    cannot_update_higher_or_equal: no puedes actualizar un rol de nivel mayor o igual al tuyo
+    cannot_set_higher_or_equal: no puedes establecer un nivel de rol mayor o igual al del usuario actual
+    update_failed: "no se pudo actualizar el rol: {error}"
+    no_role_info: no se pudo obtener información del rol
+    cannot_delete_higher_or_equal: no puedes eliminar un rol de nivel mayor o igual al tuyo
+    delete_failed: "no se pudo eliminar el rol: {error}"
+    menu_list_failed: "no se pudieron obtener los menús de permisos del rol: {error}"
+    count_failed: no se pudo obtener el total de roles
+  group:
+    parent_info_failed: no se pudo obtener la información del grupo padre
+    dn_exists: el DN del grupo ya existe
+    ldap_create_failed: "no se pudo crear el grupo en LDAP: {error}"
+    mysql_create_failed: no se pudo crear el grupo en MySQL
+    add_user_failed: "no se pudo agregar el usuario al grupo: {error}"
+    list_failed: "no se pudo obtener la lista de grupos: {error}"
+    count_failed: no se pudo obtener el total de grupos
+    not_found: el grupo no existe
+    ldap_update_failed: "no se pudo actualizar el grupo en LDAP: {error}"
+    mysql_update_failed: no se pudo actualizar el grupo en MySQL
+    some_not_found: algunos grupos no existen
+    has_children: este grupo tiene subgrupos, elimina primero los subgrupos
+    ldap_delete_failed: "no se pudo eliminar el grupo en LDAP: {error}"
+    get_failed: "no se pudo obtener el grupo: {error}"
+    ou_cannot_add_user: los grupos OU no pueden contener usuarios
+    ou_has_no_user: los grupos OU no tienen usuarios
+    ldap_add_user_failed: "no se pudo agregar el usuario al grupo en LDAP: {error}"
+    user_department_failed: "no se pudieron procesar los datos de departamento del usuario: {error}"
+    mysql_user_update_failed: "no se pudo actualizar el usuario en MySQL: {error}"
+    ldap_remove_user_failed: "no se pudo quitar el usuario de LDAP: {error}"
+    mysql_remove_user_failed: "no se pudo quitar el usuario de MySQL: {error}"
+  base:
+    email_query_failed: "no se pudo consultar el usuario por correo: {error}"
+    ldap_new_password_failed: "no se pudo generar la nueva contraseña LDAP: {error}"
+  menu:
+    count_failed: no se pudo obtener el total de menús
+  log:
+    count_failed: no se pudo obtener el total de registros
+builtin:
+  creator:
+    系统: Sistema
+    system: Sistema
+  role:
+    admin:
+      name: Administrador
+      remark: ""
+    user:
+      name: Usuario estándar
+      remark: ""
+    guest:
+      name: Invitado
+      remark: ""
+  menu:
+    UserManage:
+      name: Personal
+      title: Personal
+    User:
+      name: Usuarios
+      title: Usuarios
+    Group:
+      name: Grupos
+      title: Grupos
+    FieldRelation:
+      name: Relaciones de campos
+      title: Relaciones de campos
+    System:
+      name: Sistema
+      title: Sistema
+    Role:
+      name: Roles
+      title: Roles
+    Menu:
+      name: Menús
+      title: Menús
+    Api:
+      name: APIs
+      title: APIs
+    Log:
+      name: Registros
+      title: Registros
+    OperationLog:
+      name: Registros de operación
+      title: Registros de operación
+  api:
+    category:
+      base: Base
+      user: Usuarios
+      group: Grupos
+      role: Roles
+      menu: Menús
+      api: APIs
+      fieldrelation: Relaciones de campos
+      log: Registros
+    remark:
+      get:
+        base_ping: Comprobación de estado
+        base_encryptpwd: Cifrar contraseña
+        base_decryptpwd: Descifrar contraseña
+        base_config: Obtener configuración del sistema
+        base_version: Obtener versión del sistema
+        base_dashboard: Obtener datos del panel
+        user_info: Obtener información del usuario actual
+        user_list: Obtener lista de usuarios
+        group_list: Obtener lista de grupos
+        group_tree: Obtener árbol de grupos
+        group_useringroup: Obtener usuarios del grupo
+        group_usernoingroup: Obtener usuarios fuera del grupo
+        role_list: Obtener lista de roles
+        role_getmenulist: Obtener menús de permisos del rol
+        role_getapilist: Obtener APIs de permisos del rol
+        menu_tree: Obtener árbol de menús
+        menu_access_tree: Obtener árbol de menús del usuario
+        api_list: Obtener lista de APIs
+        api_tree: Obtener árbol de APIs
+        fieldrelation_list: Obtener lista de relaciones dinámicas de campos
+        log_operation_list: Obtener lista de registros de operación
+      post:
+        base_login: Inicio de sesión de usuario
+        base_logout: Cierre de sesión de usuario
+        base_refreshtoken: Actualizar token JWT
+        base_sendcode: Enviar código de verificación al correo del usuario
+        base_changepwd: Cambiar contraseña por correo
+        user_changepwd: Cambiar contraseña de inicio de sesión
+        user_resetpassword: Restablecer contraseña de usuario
+        user_add: Crear usuario
+        user_update: Actualizar usuario
+        user_delete: Eliminar usuarios por lote
+        user_changeuserstatus: Cambiar estado laboral del usuario
+        user_syncdingtalkusers: Sincronizar usuarios desde DingTalk
+        user_syncwecomusers: Sincronizar usuarios desde WeCom
+        user_syncfeishuusers: Sincronizar usuarios desde Feishu
+        user_syncopenldapusers: Sincronizar usuarios desde OpenLDAP
+        user_syncsqlusers: Sincronizar usuarios de BD a LDAP
+        group_add: Crear grupo
+        group_update: Actualizar grupo
+        group_delete: Eliminar grupos por lote
+        group_adduser: Agregar usuarios al grupo
+        group_removeuser: Quitar usuarios del grupo
+        group_syncdingtalkdepts: Sincronizar departamentos desde DingTalk
+        group_syncwecomdepts: Sincronizar departamentos desde WeCom
+        group_syncfeishudepts: Sincronizar departamentos desde Feishu
+        group_syncopenldapdepts: Sincronizar departamentos desde OpenLDAP
+        group_syncsqlgroups: Sincronizar grupos de BD a LDAP
+        role_add: Crear rol
+        role_update: Actualizar rol
+        role_updatemenus: Actualizar menús de permisos del rol
+        role_updateapis: Actualizar APIs de permisos del rol
+        role_delete: Eliminar roles por lote
+        menu_add: Crear menú
+        menu_update: Actualizar menú
+        menu_delete: Eliminar menús por lote
+        api_add: Crear API
+        api_update: Actualizar API
+        api_delete: Eliminar APIs por lote
+        fieldrelation_add: Crear relación dinámica de campos
+        fieldrelation_update: Actualizar relación dinámica de campos
+        fieldrelation_delete: Eliminar relaciones dinámicas de campos por lote
+        log_operation_delete: Eliminar registros de operación por lote
+      delete:
+        log_operation_clean: Vaciar registros de operación
+  group:
+    name:
+      openldap:
+        root: root
+      dingtalk:
+        dingtalkroot: Departamento raíz de DingTalk
+      wecom:
+        wecomroot: Departamento raíz de WeCom
+      feishu:
+        feishuroot: Departamento raíz de Feishu
+      platform:
+        group: Grupo predeterminado
+    remark:
+      openldap:
+        root: Base
+      dingtalk:
+        dingtalkroot: Departamento raíz de DingTalk
+      wecom:
+        wecomroot: Departamento raíz de WeCom
+      feishu:
+        feishuroot: Departamento raíz de Feishu
+      platform:
+        group: Grupo predeterminado

--- a/locales/ja-JP.yaml
+++ b/locales/ja-JP.yaml
@@ -1,0 +1,411 @@
+common:
+  success: 成功しました
+  unknown_error: 不明なエラー
+  request_invalid: 無効なリクエスト
+error:
+  database: データベース操作に失敗しました
+  ldap: LDAP操作に失敗しました
+  operation: 操作に失敗しました
+  validator: 入力内容の検証に失敗しました
+auth:
+  login_success: ログインしました
+  logout_success: ログアウトしました
+  refresh_success: トークンを更新しました
+  jwt_failed: "JWT認証に失敗しました。コード: {code}, メッセージ: {message}"
+  not_logged_in: ログインしていません
+  user_not_found: ユーザーが存在しません
+  user_disabled: 現在のユーザーは無効化されています
+  password_incorrect: パスワードが正しくありません
+  no_permission: 権限がありません
+rate_limit:
+  limited: リクエストが多すぎます
+email:
+  password_reset_subject: LDAPパスワードのリセットが完了しました
+  password_reset_body: "<li><a>変更後のパスワード: %s </a></li>"
+  verification_code_subject: 確認コード - パスワードリセット
+  verification_code_body: "<div><div>こんにちは。</div><div style=\"padding: 8px 40px 8px 50px;\"><p>今回の確認コードは %s です。アカウント保護のため、このコードの有効期限は5分です。ご本人の操作であることを確認し、他人に共有しないでください。</p></div><div><p>このメールはシステムから送信されています。返信しないでください。</p></div></div>"
+  user_creation_subject: LDAPアカウント作成完了のお知らせ
+  user_creation_body: "<div><div>%s 様、こんにちは。</div><div style=\"padding: 8px 40px 8px 50px;\"><p>LDAPアカウントが作成されました。アカウント情報は以下の通りです。</p><ul><li>ユーザー名: %s</li><li>ニックネーム: %s</li><li>初期パスワード: %s</li></ul><p style=\"color: #ff6600;\">アカウント情報を安全に保管し、初回ログイン後に速やかにパスワードを変更してください。</p></div><div><p>このメールはシステムから送信されています。返信しないでください。</p></div></div>"
+  admin_password_reset_subject: LDAPパスワードリセットのお知らせ
+  admin_password_reset_body: "<div><div>%s 様、こんにちは。</div><div style=\"padding: 8px 40px 8px 50px;\"><p>LDAPアカウントのパスワードがリセットされました。新しいパスワード情報は以下の通りです。</p><ul><li>ユーザー名: %s</li><li>新しいパスワード: %s</li></ul><p style=\"color: #ff6600;\">アカウント保護のため、できるだけ早くログインしてパスワードを変更してください。</p><p style=\"color: #ff0000;\">アカウント情報を安全に保管し、他人に共有しないでください。</p></div><div><p>このメールはシステムから送信されています。返信しないでください。</p></div></div>"
+dashboard:
+  user: ユーザー
+  group: グループ
+  role: ロール
+  menu: メニュー
+  api: API
+  log: ログ
+sync:
+  dept_list_failed: "{provider}の部署一覧取得に失敗しました: {error}"
+  dept_convert_failed: "{provider}の部署データ変換に失敗しました: {error}"
+  empty_depts: 取得した部署数が0です
+  dept_add_failed: "部署[{dept}]の追加に失敗しました: {error}"
+  child_dept_add_failed: "子部署の追加に失敗しました: {error}"
+  parent_dept_query_failed: "親部署の検索に失敗しました: {error}"
+  add_dept_failed: "部署{dept}の追加に失敗しました: {error}"
+  user_list_failed: "{provider}のユーザー一覧取得に失敗しました: {error}"
+  user_convert_failed: "{provider}のユーザーデータ変換に失敗しました: {error}"
+  empty_users: 取得したユーザー数が0です
+  user_write_failed: "ユーザー[{username}]の書き込みに失敗しました: {error}"
+  leave_user_list_failed: "{provider}の退職ユーザー一覧取得に失敗しました: {error}"
+  leave_user_query_failed: "MySQLで退職ユーザー[{username}]の検索に失敗しました: {error}"
+  leave_user_ldap_delete_failed: "LDAPで退職ユーザー[{username}]の削除に失敗しました: {error}"
+  leave_user_status_update_failed: "MySQLで退職ユーザー[{username}]の状態更新に失敗しました: {error}"
+  role_info_failed: "ロールIDによるロール情報の取得に失敗しました: {error}"
+  add_user_failed: "ユーザー{username}の追加に失敗しました: {error}"
+  mysql_user_list_failed: "MySQLユーザー一覧の取得に失敗しました: {error}"
+  dept_ids_convert_failed: "部署IDを内部部署IDへ変換できませんでした: {error}"
+  user_dept_ids_convert_failed: "ユーザー[{username}]の部署IDを内部部署IDへ変換できませんでした: {error}"
+  user_role_info_failed: "ユーザー[{username}]のロール情報取得に失敗しました: {error}"
+common_user:
+  mysql_create_failed: "MySQLでのユーザー作成に失敗しました: {error}"
+  ldap_create_failed: "LDAPでのユーザー作成に失敗しました: {error}"
+  mysql_add_group_relation_failed: "MySQLでのユーザーとグループの関連付け追加に失敗しました: {error}"
+  ldap_add_group_relation_failed: "LDAPでのユーザーとグループの関連付け追加に失敗しました: {error}"
+  ldap_update_failed: "LDAPでのユーザー更新に失敗しました: {error}"
+  mysql_update_failed: "MySQLでのユーザー更新に失敗しました: {error}"
+  mysql_remove_group_relation_failed: "MySQLでのグループからのユーザー削除に失敗しました: {error}"
+  ldap_remove_group_relation_failed: "LDAPでのグループからのユーザー削除に失敗しました: {error}"
+base:
+  email_not_found: メールアドレスが存在しません。正しいか確認してください
+  code_expired: 確認コードは5分で期限切れになりました。もう一度パスワードをリセットしてください
+  code_invalid: 確認コードが正しくありません。複数回送信した場合は最新のコードを使用してください
+  reset_password_user_unavailable: このユーザーは退職済み、またはLDAPに同期されていません。管理者に連絡してください
+  send_email_failed: "メール送信に失敗しました: {error}"
+  email_query_failed: "メールアドレスによるユーザー検索に失敗しました: {error}"
+  ldap_new_password_failed: "LDAPでの新しいパスワード生成に失敗しました: {error}"
+user:
+  username_exists: ユーザー名は既に存在します。重複して追加しないでください
+  mobile_exists: 携帯番号は既に存在します。重複して追加しないでください
+  job_number_exists: 社員番号は既に存在します。重複して追加しないでください
+  mail_exists: メールアドレスは既に存在します。重複して追加しないでください
+  password_encrypt_failed: パスワードの暗号化に失敗しました
+  password_decrypt_failed: パスワードの復号に失敗しました
+  password_min_length: パスワードは少なくとも{min}文字必要です
+  cannot_delete_self: 自分自身を削除することはできません
+  not_found: ユーザーが存在しません
+  current_min_role_sort_failed: 現在ログイン中のユーザーの最小ロール順序の取得に失敗しました
+  role_info_failed: ロールIDによるロール情報の取得に失敗しました
+  cannot_create_higher_or_equal: 自分以上の権限レベルのユーザーは作成できません
+  department_info_failed: "部署IDによる部署情報の取得に失敗しました: {error}"
+  create_failed: "ユーザーの追加に失敗しました: {error}"
+  list_failed: "ユーザー一覧の取得に失敗しました: {error}"
+  count_failed: "ユーザー数の取得に失敗しました: {error}"
+  cannot_change_self_role: 自分のロールは変更できません
+  min_role_sort_by_id_failed: ユーザーIDによる最小ロール順序の取得に失敗しました
+  cannot_update_higher_or_equal: 自分以上の権限レベルのユーザーは更新できません
+  update_failed: "ユーザーの更新に失敗しました: {error}"
+  cannot_delete_higher: 自分より高い権限レベルのユーザーは削除できません
+  info_failed: "ユーザー情報の取得に失敗しました: {error}"
+  ldap_delete_failed: "LDAPでのユーザー削除に失敗しました: {error}"
+  mysql_delete_failed: "MySQLでのユーザー削除に失敗しました: {error}"
+  ldap_password_update_failed: "LDAPでのパスワード更新に失敗しました: {error}"
+  mysql_password_update_failed: "MySQLでのパスワード更新に失敗しました: {error}"
+  mysql_query_failed: "MySQLでのユーザー検索に失敗しました: {error}"
+  ldap_add_failed: "LDAPでのユーザー追加に失敗しました: {error}"
+  mysql_status_update_failed: "MySQLでのユーザー状態更新に失敗しました: {error}"
+  current_info_failed: "現在のユーザー情報の取得に失敗しました: {error}"
+menu:
+  name_exists: メニュー名は既に存在します
+  create_failed: "レコードの作成に失敗しました: {error}"
+  update_failed: "レコードの更新に失敗しました: {error}"
+  delete_failed: "APIの削除に失敗しました: {error}"
+  record_not_found: このIDに対応するレコードは存在しません
+  record_get_failed: "レコードの取得に失敗しました: {error}"
+  count_failed: メニュー数の取得に失敗しました
+api:
+  create_failed: "APIの作成に失敗しました: {error}"
+  list_failed: "API一覧の取得に失敗しました: {error}"
+  count_failed: API数の取得に失敗しました
+  not_found: APIが存在しません
+  update_failed: "APIの更新に失敗しました: {error}"
+  delete_failed: "APIの削除に失敗しました: {error}"
+operation_log:
+  list_failed: "操作ログ一覧の取得に失敗しました: {error}"
+  count_failed: 操作ログ数の取得に失敗しました
+  not_found: 操作ログレコードが存在しません
+  delete_failed: "操作ログレコードの削除に失敗しました: {error}"
+  clean_failed: "操作ログのクリアに失敗しました: {error}"
+role:
+  name_exists: ロール名は既に存在します
+  not_found: ロールが存在しません
+  current_max_sort_failed: "現在のユーザーの最高ロールレベル取得に失敗しました: {error}"
+  no_update_permission: 現在のユーザーにはロール更新権限がありません
+  cannot_create_higher_or_equal: 自分以上のレベルのロールは作成できません
+  create_failed: "ロール作成に失敗しました: {error}"
+  list_failed: "ロール一覧の取得に失敗しました: {error}"
+  count_failed: ロール数の取得に失敗しました
+  info_not_found: ロール情報の取得に失敗しました。該当ロールが見つかりません
+  cannot_update_higher_or_equal: 自分以上のレベルのロールは更新できません
+  cannot_set_higher_or_equal: ロールレベルを現在のユーザー以上に設定できません
+  update_failed: "ロール更新に失敗しました: {error}"
+  keyword_policy_update_failed: ロールは更新されましたが、ロールキーワードに紐づく権限APIの更新に失敗しました
+  keyword_policy_load_failed: ロールは更新されましたが、ロールキーワードに紐づく権限APIポリシーの読み込みに失敗しました
+  no_role_info: ロール情報を取得できませんでした
+  cannot_delete_higher_or_equal: 自分以上のレベルのロールは削除できません
+  delete_failed: "ロール削除に失敗しました: {error}"
+  menu_list_failed: "ロール権限メニューの取得に失敗しました: {error}"
+  resource_failed: "リソース取得に失敗しました: {error}"
+  cannot_update_higher_or_equal_permissions: 自分以上のレベルのロール権限メニューは更新できません
+  current_user_menu_list_failed: "現在のユーザーがアクセス可能なメニュー一覧の取得に失敗しました: {error}"
+  no_menu_permission: "ID {id} のメニューを設定する権限がありません"
+  menu_all_list_failed: "メニュー一覧の取得に失敗しました: {error}"
+  update_menus_failed: "ロール権限メニューの更新に失敗しました: {error}"
+  api_info_failed: API IDからAPI情報を取得できませんでした
+  no_api_permission: "パス {path}、方式 {method} のAPIを設定する権限がありません"
+  update_apis_failed: ロール権限APIの更新に失敗しました
+group:
+  parent_info_failed: 親グループ情報の取得に失敗しました
+  dn_exists: グループDNは既に存在します
+  ldap_create_failed: "LDAPでのグループ作成に失敗しました: {error}"
+  mysql_create_failed: MySQLでのグループ作成に失敗しました
+  add_user_failed: "グループへのユーザー追加に失敗しました: {error}"
+  user_list_failed: "ユーザー一覧の取得に失敗しました: {error}"
+  list_failed: "グループ一覧の取得に失敗しました: {error}"
+  count_failed: グループ数の取得に失敗しました
+  not_found: グループが存在しません
+  ldap_update_failed: "LDAPでのグループ更新に失敗しました: {error}"
+  mysql_update_failed: MySQLでのグループ更新に失敗しました
+  some_not_found: 存在しないグループがあります
+  has_children: このグループには子グループがあります。先に子グループを削除してください
+  ldap_delete_failed: "LDAPでのグループ削除に失敗しました: {error}"
+  delete_failed: "グループ削除に失敗しました: {error}"
+  get_failed: "グループ取得に失敗しました: {error}"
+  ou_cannot_add_user: OUグループにはユーザーを追加できません
+  ou_has_no_user: OUグループにはユーザーがいません
+  ldap_add_user_failed: "LDAPでのグループへのユーザー追加に失敗しました: {error}"
+  user_department_failed: "ユーザー部署データの処理に失敗しました: {error}"
+  mysql_user_update_failed: "MySQLでのユーザー更新に失敗しました: {error}"
+  ldap_remove_user_failed: "LDAPからのユーザー削除に失敗しました: {error}"
+  mysql_remove_user_failed: "MySQLからのユーザー削除に失敗しました: {error}"
+field_relation:
+  exists: このプラットフォームの動的フィールド関連は既に存在します
+  not_found: このプラットフォームの動的フィールド関連は存在しません
+  map_to_json_failed: "mapからJSONへの変換に失敗しました: {error}"
+  create_failed: "動的フィールド関連の作成に失敗しました: {error}"
+  list_failed: "動的フィールド関連一覧の取得に失敗しました: {error}"
+  update_failed: "動的フィールド関連の更新に失敗しました: {error}"
+  delete_failed: "動的フィールド関連の削除に失敗しました: {error}"
+legacy:
+  common:
+    current_user_failed: 現在ログイン中のユーザー取得に失敗しました
+    resource_list_failed: "リソース一覧の取得に失敗しました: {error}"
+    record_not_found: レコードが存在しません
+  user:
+    some_not_found: 存在しないユーザーがあります
+    not_found: ユーザーが存在しません
+    old_password_incorrect: 現在のパスワードが正しくありません
+    old_password_parse_failed: 現在のパスワードの解析に失敗しました
+    new_password_parse_failed: 新しいパスワードの解析に失敗しました
+    already_active: ユーザーは既に在職状態です
+    already_inactive: ユーザーは既に離職状態です
+    only_admin_change_status: 管理者のみユーザー状態を変更できます
+    list_failed: "ユーザー一覧の取得に失敗しました: {error}"
+    count_failed: ユーザー数の取得に失敗しました
+    create_failed: "ユーザー追加に失敗しました: {error}"
+    update_failed: "ユーザー更新に失敗しました: {error}"
+    info_failed: "ユーザー情報の取得に失敗しました: {error}"
+    ldap_delete_failed: "LDAPでのユーザー削除に失敗しました: {error}"
+    ldap_add_failed: "LDAPでのユーザー追加に失敗しました: {error}"
+    ldap_password_update_failed: "LDAPでのパスワード更新に失敗しました: {error}"
+    mysql_delete_failed: "MySQLでのユーザー削除に失敗しました: {error}"
+    mysql_password_update_failed: "MySQLでのパスワード更新に失敗しました: {error}"
+    mysql_status_update_failed: "MySQLでのユーザー状態更新に失敗しました: {error}"
+  api:
+    create_failed: "APIの作成に失敗しました: {error}"
+    list_failed: "API一覧の取得に失敗しました: {error}"
+    count_failed: API数の取得に失敗しました
+    not_found: APIが存在しません
+    update_failed: "APIの更新に失敗しました: {error}"
+    delete_failed: "APIの削除に失敗しました: {error}"
+  role:
+    name_exists: ロール名は既に存在します
+    not_found: ロールが存在しません
+    current_max_sort_failed: "現在ユーザーの最高ロールレベル取得に失敗しました: {error}"
+    no_update_permission: 現在のユーザーにはロール更新権限がありません
+    cannot_create_higher_or_equal: 自分以上のレベルのロールは作成できません
+    create_failed: "ロール作成に失敗しました: {error}"
+    list_failed: "ロール一覧の取得に失敗しました: {error}"
+    info_failed: "ロール情報の取得に失敗しました: {error}"
+    cannot_update_higher_or_equal: 自分以上のレベルのロールは更新できません
+    cannot_set_higher_or_equal: ロールレベルを現在ユーザー以上に設定できません
+    update_failed: "ロール更新に失敗しました: {error}"
+    no_role_info: ロール情報を取得できませんでした
+    cannot_delete_higher_or_equal: 自分以上のレベルのロールは削除できません
+    delete_failed: "ロール削除に失敗しました: {error}"
+    menu_list_failed: "ロール権限メニュー取得に失敗しました: {error}"
+    count_failed: ロール数の取得に失敗しました
+  group:
+    parent_info_failed: 親グループ情報の取得に失敗しました
+    dn_exists: グループDNは既に存在します
+    ldap_create_failed: "LDAPでのグループ作成に失敗しました: {error}"
+    mysql_create_failed: MySQLでのグループ作成に失敗しました
+    add_user_failed: "グループへのユーザー追加に失敗しました: {error}"
+    list_failed: "グループ一覧の取得に失敗しました: {error}"
+    count_failed: グループ数の取得に失敗しました
+    not_found: グループが存在しません
+    ldap_update_failed: "LDAPでのグループ更新に失敗しました: {error}"
+    mysql_update_failed: MySQLでのグループ更新に失敗しました
+    some_not_found: 存在しないグループがあります
+    has_children: 子グループが存在します。先に子グループを削除してください
+    ldap_delete_failed: "LDAPでのグループ削除に失敗しました: {error}"
+    get_failed: "グループ取得に失敗しました: {error}"
+    ou_cannot_add_user: OUタイプのグループにはユーザーを追加できません
+    ou_has_no_user: OUタイプのグループにはユーザーがありません
+    ldap_add_user_failed: "LDAPでのグループへのユーザー追加に失敗しました: {error}"
+    user_department_failed: "ユーザー部署データの処理に失敗しました: {error}"
+    mysql_user_update_failed: "MySQLでのユーザー更新に失敗しました: {error}"
+    ldap_remove_user_failed: "LDAPからのユーザー削除に失敗しました: {error}"
+    mysql_remove_user_failed: "MySQLからのユーザー削除に失敗しました: {error}"
+  base:
+    email_query_failed: "メールによるユーザー検索に失敗しました: {error}"
+    ldap_new_password_failed: "LDAP新規パスワード生成に失敗しました: {error}"
+  menu:
+    count_failed: メニュー数の取得に失敗しました
+  log:
+    count_failed: ログ数の取得に失敗しました
+builtin:
+  creator:
+    系统: システム
+    system: システム
+  role:
+    admin:
+      name: 管理者
+      remark: ""
+    user:
+      name: 標準ユーザー
+      remark: ""
+    guest:
+      name: ゲスト
+      remark: ""
+  menu:
+    UserManage:
+      name: 人員管理
+      title: 人員管理
+    User:
+      name: ユーザー管理
+      title: ユーザー管理
+    Group:
+      name: グループ管理
+      title: グループ管理
+    FieldRelation:
+      name: フィールド関連管理
+      title: フィールド関連管理
+    System:
+      name: システム管理
+      title: システム管理
+    Role:
+      name: ロール管理
+      title: ロール管理
+    Menu:
+      name: メニュー管理
+      title: メニュー管理
+    Api:
+      name: API管理
+      title: API管理
+    Log:
+      name: ログ管理
+      title: ログ管理
+    OperationLog:
+      name: 操作ログ
+      title: 操作ログ
+  api:
+    category:
+      base: 基本管理
+      user: ユーザー管理
+      group: グループ管理
+      role: ロール管理
+      menu: メニュー管理
+      api: API管理
+      fieldrelation: フィールド関連管理
+      log: ログ管理
+    remark:
+      get:
+        base_ping: ヘルスチェック
+        base_encryptpwd: パスワード暗号化
+        base_decryptpwd: パスワード復号
+        base_config: システム設定取得
+        base_version: システムバージョン取得
+        base_dashboard: ダッシュボードデータ取得
+        user_info: 現在ユーザー情報取得
+        user_list: ユーザー一覧取得
+        group_list: グループ一覧取得
+        group_tree: グループツリー取得
+        group_useringroup: グループ内ユーザー取得
+        group_usernoingroup: グループ外ユーザー取得
+        role_list: ロール一覧取得
+        role_getmenulist: ロール権限メニュー取得
+        role_getapilist: ロール権限API取得
+        menu_tree: メニューツリー取得
+        menu_access_tree: ユーザーメニューツリー取得
+        api_list: API一覧取得
+        api_tree: APIツリー取得
+        fieldrelation_list: 動的フィールド関連一覧取得
+        log_operation_list: 操作ログ一覧取得
+      post:
+        base_login: ユーザーログイン
+        base_logout: ユーザーログアウト
+        base_refreshtoken: JWTトークン更新
+        base_sendcode: ユーザーメールへ確認コード送信
+        base_changepwd: メールによるパスワード変更
+        user_changepwd: ユーザーログインパスワード変更
+        user_resetpassword: ユーザーパスワードリセット
+        user_add: ユーザー作成
+        user_update: ユーザー更新
+        user_delete: ユーザー一括削除
+        user_changeuserstatus: ユーザー在職状態変更
+        user_syncdingtalkusers: DingTalkからユーザー同期
+        user_syncwecomusers: WeComからユーザー同期
+        user_syncfeishuusers: Feishuからユーザー同期
+        user_syncopenldapusers: OpenLDAPからユーザー同期
+        user_syncsqlusers: DBユーザーをLDAPへ同期
+        group_add: グループ作成
+        group_update: グループ更新
+        group_delete: グループ一括削除
+        group_adduser: ユーザーをグループへ追加
+        group_removeuser: ユーザーをグループから削除
+        group_syncdingtalkdepts: DingTalkから部署同期
+        group_syncwecomdepts: WeComから部署同期
+        group_syncfeishudepts: Feishuから部署同期
+        group_syncopenldapdepts: OpenLDAPから部署同期
+        group_syncsqlgroups: DBグループをLDAPへ同期
+        role_add: ロール作成
+        role_update: ロール更新
+        role_updatemenus: ロール権限メニュー更新
+        role_updateapis: ロール権限API更新
+        role_delete: ロール一括削除
+        menu_add: メニュー作成
+        menu_update: メニュー更新
+        menu_delete: メニュー一括削除
+        api_add: API作成
+        api_update: API更新
+        api_delete: API一括削除
+        fieldrelation_add: 動的フィールド関連作成
+        fieldrelation_update: 動的フィールド関連更新
+        fieldrelation_delete: 動的フィールド関連一括削除
+        log_operation_delete: 操作ログ一括削除
+      delete:
+        log_operation_clean: 操作ログをクリア
+  group:
+    name:
+      openldap:
+        root: root
+      dingtalk:
+        dingtalkroot: DingTalkルート部署
+      wecom:
+        wecomroot: WeComルート部署
+      feishu:
+        feishuroot: Feishuルート部署
+      platform:
+        group: デフォルトグループ
+    remark:
+      openldap:
+        root: Base
+      dingtalk:
+        dingtalkroot: DingTalkルート部署
+      wecom:
+        wecomroot: WeComルート部署
+      feishu:
+        feishuroot: Feishuルート部署
+      platform:
+        group: デフォルトグループ

--- a/locales/ko-KR.yaml
+++ b/locales/ko-KR.yaml
@@ -1,0 +1,411 @@
+common:
+  success: 성공
+  unknown_error: 알 수 없는 오류
+  request_invalid: 잘못된 요청
+error:
+  database: 데이터베이스 작업 실패
+  ldap: LDAP 작업 실패
+  operation: 작업 실패
+  validator: 유효성 검사 실패
+auth:
+  login_success: 로그인 성공
+  logout_success: 로그아웃 성공
+  refresh_success: 토큰이 성공적으로 갱신되었습니다
+  jwt_failed: "JWT 인증 실패, 코드: {code}, 메시지: {message}"
+  not_logged_in: 사용자가 로그인하지 않았습니다
+  user_not_found: 사용자가 존재하지 않습니다
+  user_disabled: 현재 사용자가 비활성화되었습니다
+  password_incorrect: 비밀번호가 올바르지 않습니다
+  no_permission: 권한이 없습니다
+rate_limit:
+  limited: 요청이 너무 많습니다
+email:
+  password_reset_subject: LDAP 비밀번호 재설정 완료
+  password_reset_body: "<li><a>변경된 비밀번호: %s </a></li>"
+  verification_code_subject: 인증 코드 - 비밀번호 재설정
+  verification_code_body: "<div><div>안녕하세요.</div><div style=\"padding: 8px 40px 8px 50px;\"><p>이번 인증 코드는 %s 입니다. 계정 보안을 위해 인증 코드는 5분간 유효합니다. 본인 작업인지 확인하고 다른 사람에게 공유하지 마세요.</p></div><div><p>이 메일은 시스템 메일입니다. 회신하지 마세요.</p></div></div>"
+  user_creation_subject: LDAP 계정 생성 완료 알림
+  user_creation_body: "<div><div>%s 님, 안녕하세요.</div><div style=\"padding: 8px 40px 8px 50px;\"><p>LDAP 계정이 생성되었습니다. 계정 정보는 다음과 같습니다.</p><ul><li>사용자 이름: %s</li><li>닉네임: %s</li><li>초기 비밀번호: %s</li></ul><p style=\"color: #ff6600;\">계정 정보를 안전하게 보관하고 첫 로그인 후 비밀번호를 변경하세요.</p></div><div><p>이 메일은 시스템 메일입니다. 회신하지 마세요.</p></div></div>"
+  admin_password_reset_subject: LDAP 비밀번호 재설정 알림
+  admin_password_reset_body: "<div><div>%s 님, 안녕하세요.</div><div style=\"padding: 8px 40px 8px 50px;\"><p>LDAP 계정 비밀번호가 재설정되었습니다. 새 비밀번호 정보는 다음과 같습니다.</p><ul><li>사용자 이름: %s</li><li>새 비밀번호: %s</li></ul><p style=\"color: #ff6600;\">계정 보안을 위해 가능한 한 빨리 로그인하여 비밀번호를 변경하세요.</p><p style=\"color: #ff0000;\">계정 정보를 안전하게 보관하고 다른 사람에게 공유하지 마세요.</p></div><div><p>이 메일은 시스템 메일입니다. 회신하지 마세요.</p></div></div>"
+dashboard:
+  user: 사용자
+  group: 그룹
+  role: 역할
+  menu: 메뉴
+  api: API
+  log: 로그
+sync:
+  dept_list_failed: "{provider} 부서 목록 조회 실패: {error}"
+  dept_convert_failed: "{provider} 부서 데이터 변환 실패: {error}"
+  empty_depts: 조회된 부서 수가 0입니다
+  dept_add_failed: "부서 [{dept}] 추가 실패: {error}"
+  child_dept_add_failed: "하위 부서 추가 실패: {error}"
+  parent_dept_query_failed: "상위 부서 조회 실패: {error}"
+  add_dept_failed: "부서 {dept} 추가 실패: {error}"
+  user_list_failed: "{provider} 사용자 목록 조회 실패: {error}"
+  user_convert_failed: "{provider} 사용자 데이터 변환 실패: {error}"
+  empty_users: 조회된 사용자 수가 0입니다
+  user_write_failed: "사용자 [{username}] 쓰기 실패: {error}"
+  leave_user_list_failed: "{provider} 퇴사 사용자 목록 조회 실패: {error}"
+  leave_user_query_failed: "MySQL에서 퇴사 사용자 [{username}] 조회 실패: {error}"
+  leave_user_ldap_delete_failed: "LDAP에서 퇴사 사용자 [{username}] 삭제 실패: {error}"
+  leave_user_status_update_failed: "MySQL에서 퇴사 사용자 [{username}] 상태 업데이트 실패: {error}"
+  role_info_failed: "역할 ID로 역할 정보 조회 실패: {error}"
+  add_user_failed: "사용자 {username} 추가 실패: {error}"
+  mysql_user_list_failed: "MySQL 사용자 목록 조회 실패: {error}"
+  dept_ids_convert_failed: "부서 ID를 내부 부서 ID로 변환 실패: {error}"
+  user_dept_ids_convert_failed: "사용자 [{username}]의 부서 ID를 내부 부서 ID로 변환 실패: {error}"
+  user_role_info_failed: "사용자 [{username}]의 역할 정보 조회 실패: {error}"
+common_user:
+  mysql_create_failed: "MySQL 사용자 생성 실패: {error}"
+  ldap_create_failed: "LDAP 사용자 생성 실패: {error}"
+  mysql_add_group_relation_failed: "MySQL 사용자-그룹 관계 추가 실패: {error}"
+  ldap_add_group_relation_failed: "LDAP 사용자-그룹 관계 추가 실패: {error}"
+  ldap_update_failed: "LDAP 사용자 업데이트 실패: {error}"
+  mysql_update_failed: "MySQL 사용자 업데이트 실패: {error}"
+  mysql_remove_group_relation_failed: "MySQL에서 그룹의 사용자 제거 실패: {error}"
+  ldap_remove_group_relation_failed: "LDAP에서 그룹의 사용자 제거 실패: {error}"
+base:
+  email_not_found: 이메일이 존재하지 않습니다. 이메일 주소를 확인하세요
+  code_expired: 인증 코드가 5분 후 만료되었습니다. 비밀번호를 다시 재설정하세요
+  code_invalid: 인증 코드가 올바르지 않습니다. 여러 번 전송했다면 마지막으로 생성된 코드를 사용하세요
+  reset_password_user_unavailable: 이 사용자는 퇴사했거나 LDAP에 동기화되지 않았습니다. 관리자에게 문의하세요
+  send_email_failed: "이메일 전송 실패: {error}"
+  email_query_failed: "이메일로 사용자 조회 실패: {error}"
+  ldap_new_password_failed: "LDAP에서 새 비밀번호 생성 실패: {error}"
+user:
+  username_exists: 사용자 이름이 이미 존재합니다. 중복 추가하지 마세요
+  mobile_exists: 휴대폰 번호가 이미 존재합니다. 중복 추가하지 마세요
+  job_number_exists: 사번이 이미 존재합니다. 중복 추가하지 마세요
+  mail_exists: 이메일이 이미 존재합니다. 중복 추가하지 마세요
+  password_encrypt_failed: 비밀번호 암호화 실패
+  password_decrypt_failed: 비밀번호 복호화 실패
+  password_min_length: 비밀번호는 최소 {min}자 이상이어야 합니다
+  cannot_delete_self: 사용자는 자신을 삭제할 수 없습니다
+  not_found: 사용자가 존재하지 않습니다
+  current_min_role_sort_failed: 현재 로그인 사용자의 최소 역할 정렬값 조회 실패
+  role_info_failed: 역할 ID로 역할 정보 조회 실패
+  cannot_create_higher_or_equal: 자신보다 높거나 같은 역할 등급의 사용자는 생성할 수 없습니다
+  department_info_failed: "부서 ID로 부서 정보 조회 실패: {error}"
+  create_failed: "사용자 추가 실패: {error}"
+  list_failed: "사용자 목록 조회 실패: {error}"
+  count_failed: "사용자 수 조회 실패: {error}"
+  cannot_change_self_role: 자신의 역할은 변경할 수 없습니다
+  min_role_sort_by_id_failed: 사용자 ID로 최소 역할 정렬값 조회 실패
+  cannot_update_higher_or_equal: 자신보다 높거나 같은 역할 등급의 사용자는 업데이트할 수 없습니다
+  update_failed: "사용자 업데이트 실패: {error}"
+  cannot_delete_higher: 자신보다 높은 역할 등급의 사용자는 삭제할 수 없습니다
+  info_failed: "사용자 정보 조회 실패: {error}"
+  ldap_delete_failed: "LDAP에서 사용자 삭제 실패: {error}"
+  mysql_delete_failed: "MySQL에서 사용자 삭제 실패: {error}"
+  ldap_password_update_failed: "LDAP에서 비밀번호 업데이트 실패: {error}"
+  mysql_password_update_failed: "MySQL에서 비밀번호 업데이트 실패: {error}"
+  mysql_query_failed: "MySQL에서 사용자 조회 실패: {error}"
+  ldap_add_failed: "LDAP에 사용자 추가 실패: {error}"
+  mysql_status_update_failed: "MySQL에서 사용자 상태 업데이트 실패: {error}"
+  current_info_failed: "현재 사용자 정보 조회 실패: {error}"
+menu:
+  name_exists: 메뉴 이름이 이미 존재합니다
+  create_failed: "레코드 생성 실패: {error}"
+  update_failed: "레코드 업데이트 실패: {error}"
+  delete_failed: "API 삭제 실패: {error}"
+  record_not_found: 이 ID에 해당하는 레코드가 존재하지 않습니다
+  record_get_failed: "레코드 조회 실패: {error}"
+  count_failed: 메뉴 수 조회 실패
+api:
+  create_failed: "API 생성 실패: {error}"
+  list_failed: "API 목록 조회 실패: {error}"
+  count_failed: API 수 조회 실패
+  not_found: API가 존재하지 않습니다
+  update_failed: "API 업데이트 실패: {error}"
+  delete_failed: "API 삭제 실패: {error}"
+operation_log:
+  list_failed: "작업 로그 목록 조회 실패: {error}"
+  count_failed: 작업 로그 수 조회 실패
+  not_found: 작업 로그 레코드가 존재하지 않습니다
+  delete_failed: "작업 로그 레코드 삭제 실패: {error}"
+  clean_failed: "작업 로그 비우기 실패: {error}"
+role:
+  name_exists: 역할 이름이 이미 존재합니다
+  not_found: 역할이 존재하지 않습니다
+  current_max_sort_failed: "현재 사용자의 최고 역할 레벨 조회 실패: {error}"
+  no_update_permission: 현재 사용자는 역할을 업데이트할 권한이 없습니다
+  cannot_create_higher_or_equal: 자신보다 높거나 같은 레벨의 역할은 생성할 수 없습니다
+  create_failed: "역할 생성 실패: {error}"
+  list_failed: "역할 목록 조회 실패: {error}"
+  count_failed: 역할 수 조회 실패
+  info_not_found: 역할 정보 조회 실패, 해당 역할을 찾을 수 없습니다
+  cannot_update_higher_or_equal: 자신보다 높거나 같은 레벨의 역할은 업데이트할 수 없습니다
+  cannot_set_higher_or_equal: 역할 레벨을 현재 사용자보다 높거나 같게 설정할 수 없습니다
+  update_failed: "역할 업데이트 실패: {error}"
+  keyword_policy_update_failed: 역할은 업데이트되었지만 역할 키워드에 연결된 권한 API 업데이트에 실패했습니다
+  keyword_policy_load_failed: 역할은 업데이트되었지만 역할 키워드에 연결된 권한 API 정책 로드에 실패했습니다
+  no_role_info: 역할 정보를 가져오지 못했습니다
+  cannot_delete_higher_or_equal: 자신보다 높거나 같은 레벨의 역할은 삭제할 수 없습니다
+  delete_failed: "역할 삭제 실패: {error}"
+  menu_list_failed: "역할 권한 메뉴 조회 실패: {error}"
+  resource_failed: "리소스 조회 실패: {error}"
+  cannot_update_higher_or_equal_permissions: 자신보다 높거나 같은 레벨 역할의 권한 메뉴는 업데이트할 수 없습니다
+  current_user_menu_list_failed: "현재 사용자의 접근 가능한 메뉴 목록 조회 실패: {error}"
+  no_menu_permission: "ID가 {id}인 메뉴를 설정할 권한이 없습니다"
+  menu_all_list_failed: "메뉴 목록 조회 실패: {error}"
+  update_menus_failed: "역할 권한 메뉴 업데이트 실패: {error}"
+  api_info_failed: API ID로 API 정보를 가져오지 못했습니다
+  no_api_permission: "경로 {path}, 요청 방식 {method} API를 설정할 권한이 없습니다"
+  update_apis_failed: 역할 권한 API 업데이트 실패
+group:
+  parent_info_failed: 상위 그룹 정보 조회 실패
+  dn_exists: 그룹 DN이 이미 존재합니다
+  ldap_create_failed: "LDAP 그룹 생성 실패: {error}"
+  mysql_create_failed: MySQL 그룹 생성 실패
+  add_user_failed: "그룹에 사용자 추가 실패: {error}"
+  user_list_failed: "사용자 목록 조회 실패: {error}"
+  list_failed: "그룹 목록 조회 실패: {error}"
+  count_failed: 그룹 수 조회 실패
+  not_found: 그룹이 존재하지 않습니다
+  ldap_update_failed: "LDAP 그룹 업데이트 실패: {error}"
+  mysql_update_failed: MySQL 그룹 업데이트 실패
+  some_not_found: 일부 그룹이 존재하지 않습니다
+  has_children: 이 그룹에는 하위 그룹이 있습니다. 먼저 하위 그룹을 삭제하세요
+  ldap_delete_failed: "LDAP 그룹 삭제 실패: {error}"
+  delete_failed: "그룹 삭제 실패: {error}"
+  get_failed: "그룹 조회 실패: {error}"
+  ou_cannot_add_user: OU 그룹에는 사용자를 추가할 수 없습니다
+  ou_has_no_user: OU 그룹에는 사용자가 없습니다
+  ldap_add_user_failed: "LDAP 그룹에 사용자 추가 실패: {error}"
+  user_department_failed: "사용자의 부서 데이터 처리 실패: {error}"
+  mysql_user_update_failed: "MySQL 사용자 업데이트 실패: {error}"
+  ldap_remove_user_failed: "LDAP에서 사용자 제거 실패: {error}"
+  mysql_remove_user_failed: "MySQL에서 사용자 제거 실패: {error}"
+field_relation:
+  exists: 해당 플랫폼의 동적 필드 관계가 이미 존재합니다
+  not_found: 해당 플랫폼의 동적 필드 관계가 존재하지 않습니다
+  map_to_json_failed: "map을 JSON으로 변환하지 못했습니다: {error}"
+  create_failed: "동적 필드 관계 생성 실패: {error}"
+  list_failed: "동적 필드 관계 목록 조회 실패: {error}"
+  update_failed: "동적 필드 관계 업데이트 실패: {error}"
+  delete_failed: "동적 필드 관계 삭제 실패: {error}"
+legacy:
+  common:
+    current_user_failed: 현재 로그인 사용자를 가져오지 못했습니다
+    resource_list_failed: "리소스 목록 조회 실패: {error}"
+    record_not_found: 레코드가 존재하지 않습니다
+  user:
+    some_not_found: 일부 사용자가 존재하지 않습니다
+    not_found: 사용자가 존재하지 않습니다
+    old_password_incorrect: 기존 비밀번호가 올바르지 않습니다
+    old_password_parse_failed: 기존 비밀번호 파싱 실패
+    new_password_parse_failed: 새 비밀번호 파싱 실패
+    already_active: 사용자가 이미 재직 상태입니다
+    already_inactive: 사용자가 이미 퇴사 상태입니다
+    only_admin_change_status: 관리자만 사용자 상태를 변경할 수 있습니다
+    list_failed: "사용자 목록 조회 실패: {error}"
+    count_failed: 사용자 수 조회 실패
+    create_failed: "사용자 추가 실패: {error}"
+    update_failed: "사용자 업데이트 실패: {error}"
+    info_failed: "사용자 정보 조회 실패: {error}"
+    ldap_delete_failed: "LDAP 사용자 삭제 실패: {error}"
+    ldap_add_failed: "LDAP 사용자 추가 실패: {error}"
+    ldap_password_update_failed: "LDAP 비밀번호 업데이트 실패: {error}"
+    mysql_delete_failed: "MySQL 사용자 삭제 실패: {error}"
+    mysql_password_update_failed: "MySQL 비밀번호 업데이트 실패: {error}"
+    mysql_status_update_failed: "MySQL 사용자 상태 업데이트 실패: {error}"
+  api:
+    create_failed: "API 생성 실패: {error}"
+    list_failed: "API 목록 조회 실패: {error}"
+    count_failed: API 수 조회 실패
+    not_found: API가 존재하지 않습니다
+    update_failed: "API 업데이트 실패: {error}"
+    delete_failed: "API 삭제 실패: {error}"
+  role:
+    name_exists: 역할 이름이 이미 존재합니다
+    not_found: 역할이 존재하지 않습니다
+    current_max_sort_failed: "현재 사용자의 최고 역할 레벨 조회 실패: {error}"
+    no_update_permission: 현재 사용자에게 역할 업데이트 권한이 없습니다
+    cannot_create_higher_or_equal: 자신보다 높거나 같은 레벨의 역할을 만들 수 없습니다
+    create_failed: "역할 생성 실패: {error}"
+    list_failed: "역할 목록 조회 실패: {error}"
+    info_failed: "역할 정보 조회 실패: {error}"
+    cannot_update_higher_or_equal: 자신보다 높거나 같은 레벨의 역할을 업데이트할 수 없습니다
+    cannot_set_higher_or_equal: 역할 레벨을 현재 사용자보다 높거나 같게 설정할 수 없습니다
+    update_failed: "역할 업데이트 실패: {error}"
+    no_role_info: 역할 정보를 가져오지 못했습니다
+    cannot_delete_higher_or_equal: 자신보다 높거나 같은 레벨의 역할을 삭제할 수 없습니다
+    delete_failed: "역할 삭제 실패: {error}"
+    menu_list_failed: "역할 권한 메뉴 조회 실패: {error}"
+    count_failed: 역할 수 조회 실패
+  group:
+    parent_info_failed: 상위 그룹 정보 조회 실패
+    dn_exists: 그룹 DN이 이미 존재합니다
+    ldap_create_failed: "LDAP 그룹 생성 실패: {error}"
+    mysql_create_failed: MySQL 그룹 생성 실패
+    add_user_failed: "그룹에 사용자 추가 실패: {error}"
+    list_failed: "그룹 목록 조회 실패: {error}"
+    count_failed: 그룹 수 조회 실패
+    not_found: 그룹이 존재하지 않습니다
+    ldap_update_failed: "LDAP 그룹 업데이트 실패: {error}"
+    mysql_update_failed: MySQL 그룹 업데이트 실패
+    some_not_found: 일부 그룹이 존재하지 않습니다
+    has_children: 하위 그룹이 있습니다. 먼저 하위 그룹을 삭제하세요
+    ldap_delete_failed: "LDAP 그룹 삭제 실패: {error}"
+    get_failed: "그룹 조회 실패: {error}"
+    ou_cannot_add_user: OU 유형 그룹에는 사용자를 추가할 수 없습니다
+    ou_has_no_user: OU 유형 그룹에는 사용자가 없습니다
+    ldap_add_user_failed: "LDAP 그룹에 사용자 추가 실패: {error}"
+    user_department_failed: "사용자 부서 데이터 처리 실패: {error}"
+    mysql_user_update_failed: "MySQL 사용자 업데이트 실패: {error}"
+    ldap_remove_user_failed: "LDAP에서 사용자 제거 실패: {error}"
+    mysql_remove_user_failed: "MySQL에서 사용자 제거 실패: {error}"
+  base:
+    email_query_failed: "이메일로 사용자 조회 실패: {error}"
+    ldap_new_password_failed: "LDAP 새 비밀번호 생성 실패: {error}"
+  menu:
+    count_failed: 메뉴 수 조회 실패
+  log:
+    count_failed: 로그 수 조회 실패
+builtin:
+  creator:
+    系统: 시스템
+    system: 시스템
+  role:
+    admin:
+      name: 관리자
+      remark: ""
+    user:
+      name: 일반 사용자
+      remark: ""
+    guest:
+      name: 게스트
+      remark: ""
+  menu:
+    UserManage:
+      name: 인사 관리
+      title: 인사 관리
+    User:
+      name: 사용자 관리
+      title: 사용자 관리
+    Group:
+      name: 그룹 관리
+      title: 그룹 관리
+    FieldRelation:
+      name: 필드 관계 관리
+      title: 필드 관계 관리
+    System:
+      name: 시스템 관리
+      title: 시스템 관리
+    Role:
+      name: 역할 관리
+      title: 역할 관리
+    Menu:
+      name: 메뉴 관리
+      title: 메뉴 관리
+    Api:
+      name: API 관리
+      title: API 관리
+    Log:
+      name: 로그 관리
+      title: 로그 관리
+    OperationLog:
+      name: 작업 로그
+      title: 작업 로그
+  api:
+    category:
+      base: 기본 관리
+      user: 사용자 관리
+      group: 그룹 관리
+      role: 역할 관리
+      menu: 메뉴 관리
+      api: API 관리
+      fieldrelation: 필드 관계 관리
+      log: 로그 관리
+    remark:
+      get:
+        base_ping: 상태 확인
+        base_encryptpwd: 비밀번호 암호화
+        base_decryptpwd: 비밀번호 복호화
+        base_config: 시스템 설정 조회
+        base_version: 시스템 버전 조회
+        base_dashboard: 대시보드 데이터 조회
+        user_info: 현재 사용자 정보 조회
+        user_list: 사용자 목록 조회
+        group_list: 그룹 목록 조회
+        group_tree: 그룹 트리 조회
+        group_useringroup: 그룹 내 사용자 조회
+        group_usernoingroup: 그룹 외 사용자 조회
+        role_list: 역할 목록 조회
+        role_getmenulist: 역할 권한 메뉴 조회
+        role_getapilist: 역할 권한 API 조회
+        menu_tree: 메뉴 트리 조회
+        menu_access_tree: 사용자 메뉴 트리 조회
+        api_list: API 목록 조회
+        api_tree: API 트리 조회
+        fieldrelation_list: 동적 필드 관계 목록 조회
+        log_operation_list: 작업 로그 목록 조회
+      post:
+        base_login: 사용자 로그인
+        base_logout: 사용자 로그아웃
+        base_refreshtoken: JWT 토큰 갱신
+        base_sendcode: 사용자 이메일로 인증 코드 전송
+        base_changepwd: 이메일로 비밀번호 변경
+        user_changepwd: 사용자 로그인 비밀번호 변경
+        user_resetpassword: 사용자 비밀번호 재설정
+        user_add: 사용자 생성
+        user_update: 사용자 업데이트
+        user_delete: 사용자 일괄 삭제
+        user_changeuserstatus: 사용자 재직 상태 변경
+        user_syncdingtalkusers: DingTalk에서 사용자 동기화
+        user_syncwecomusers: WeCom에서 사용자 동기화
+        user_syncfeishuusers: Feishu에서 사용자 동기화
+        user_syncopenldapusers: OpenLDAP에서 사용자 동기화
+        user_syncsqlusers: DB 사용자를 LDAP로 동기화
+        group_add: 그룹 생성
+        group_update: 그룹 업데이트
+        group_delete: 그룹 일괄 삭제
+        group_adduser: 그룹에 사용자 추가
+        group_removeuser: 그룹에서 사용자 제거
+        group_syncdingtalkdepts: DingTalk에서 부서 동기화
+        group_syncwecomdepts: WeCom에서 부서 동기화
+        group_syncfeishudepts: Feishu에서 부서 동기화
+        group_syncopenldapdepts: OpenLDAP에서 부서 동기화
+        group_syncsqlgroups: DB 그룹을 LDAP로 동기화
+        role_add: 역할 생성
+        role_update: 역할 업데이트
+        role_updatemenus: 역할 권한 메뉴 업데이트
+        role_updateapis: 역할 권한 API 업데이트
+        role_delete: 역할 일괄 삭제
+        menu_add: 메뉴 생성
+        menu_update: 메뉴 업데이트
+        menu_delete: 메뉴 일괄 삭제
+        api_add: API 생성
+        api_update: API 업데이트
+        api_delete: API 일괄 삭제
+        fieldrelation_add: 동적 필드 관계 생성
+        fieldrelation_update: 동적 필드 관계 업데이트
+        fieldrelation_delete: 동적 필드 관계 일괄 삭제
+        log_operation_delete: 작업 로그 일괄 삭제
+      delete:
+        log_operation_clean: 작업 로그 비우기
+  group:
+    name:
+      openldap:
+        root: root
+      dingtalk:
+        dingtalkroot: DingTalk 루트 부서
+      wecom:
+        wecomroot: WeCom 루트 부서
+      feishu:
+        feishuroot: Feishu 루트 부서
+      platform:
+        group: 기본 그룹
+    remark:
+      openldap:
+        root: Base
+      dingtalk:
+        dingtalkroot: DingTalk 루트 부서
+      wecom:
+        wecomroot: WeCom 루트 부서
+      feishu:
+        feishuroot: Feishu 루트 부서
+      platform:
+        group: 기본 그룹

--- a/locales/zh-CN.yaml
+++ b/locales/zh-CN.yaml
@@ -1,0 +1,411 @@
+common:
+  success: 成功
+  unknown_error: 未知错误
+  request_invalid: 请求异常
+error:
+  database: 数据库操作失败
+  ldap: LDAP操作失败
+  operation: 操作失败
+  validator: 参数校验失败
+auth:
+  login_success: 登录成功
+  logout_success: 退出成功
+  refresh_success: 刷新token成功
+  jwt_failed: "JWT认证失败, 错误码: {code}, 错误信息: {message}"
+  not_logged_in: 用户未登录
+  user_not_found: 用户不存在
+  user_disabled: 当前用户已被禁用
+  password_incorrect: 密码错误
+  no_permission: 没有权限
+rate_limit:
+  limited: 访问限流
+email:
+  password_reset_subject: 重置LDAP密码成功
+  password_reset_body: "<li><a>更改之后的密码为: %s </a></li>"
+  verification_code_subject: 验证码-重置密码
+  verification_code_body: "<div><div>尊敬的用户，您好！</div><div style=\"padding: 8px 40px 8px 50px;\"><p>你本次的验证码为 %s ,为了保证账号安全，验证码有效期为5分钟。请确认为本人操作，切勿向他人泄露，感谢您的理解与使用。</p></div><div><p>此邮箱为系统邮箱，请勿回复。</p></div></div>"
+  user_creation_subject: LDAP账户创建成功通知
+  user_creation_body: "<div><div>尊敬的%s，您好！</div><div style=\"padding: 8px 40px 8px 50px;\"><p>您的LDAP账户已创建成功，以下是您的账户信息：</p><ul><li>用户名：%s</li><li>昵称：%s</li><li>初始密码：%s</li></ul><p style=\"color: #ff6600;\">请妥善保管您的账户信息，建议首次登录后及时修改密码。</p></div><div><p>此邮箱为系统邮箱，请勿回复。</p></div></div>"
+  admin_password_reset_subject: LDAP密码重置成功通知
+  admin_password_reset_body: "<div><div>尊敬的%s，您好！</div><div style=\"padding: 8px 40px 8px 50px;\"><p>您的LDAP账户密码已成功重置，以下是您的新密码信息：</p><ul><li>用户名：%s</li><li>新密码：%s</li></ul><p style=\"color: #ff6600;\">为了您的账户安全，请尽快登录并修改为您自己的密码。</p><p style=\"color: #ff0000;\">请妥善保管您的账户信息，切勿泄露给他人。</p></div><div><p>此邮箱为系统邮箱，请勿回复。</p></div></div>"
+dashboard:
+  user: 用户
+  group: 分组
+  role: 角色
+  menu: 菜单
+  api: 接口
+  log: 日志
+sync:
+  dept_list_failed: "获取{provider}部门列表失败：{error}"
+  dept_convert_failed: "转换{provider}部门数据失败：{error}"
+  empty_depts: 获取到的部门数量为0
+  dept_add_failed: "添加部门[{dept}]失败: {error}"
+  child_dept_add_failed: "添加子部门失败: {error}"
+  parent_dept_query_failed: "查询父级部门失败：{error}"
+  add_dept_failed: "添加部门: {dept}, 失败: {error}"
+  user_list_failed: "获取{provider}用户列表失败：{error}"
+  user_convert_failed: "转换{provider}用户数据失败：{error}"
+  empty_users: 获取到的用户数量为0
+  user_write_failed: "写入用户[{username}]失败：{error}"
+  leave_user_list_failed: "获取{provider}离职用户列表失败：{error}"
+  leave_user_query_failed: "在MySQL查询离职用户[{username}]失败: {error}"
+  leave_user_ldap_delete_failed: "在LDAP删除离职用户[{username}]失败: {error}"
+  leave_user_status_update_failed: "在MySQL更新离职用户[{username}]状态失败: {error}"
+  role_info_failed: "根据角色ID获取角色信息失败:{error}"
+  add_user_failed: "添加用户: {username}, 失败: {error}"
+  mysql_user_list_failed: "获取MySQL用户列表失败：{error}"
+  dept_ids_convert_failed: "将部门ids转换为内部部门id失败：{error}"
+  user_dept_ids_convert_failed: "将用户[{username}]的部门ids转换为内部部门id失败：{error}"
+  user_role_info_failed: "获取用户[{username}]的角色信息失败：{error}"
+common_user:
+  mysql_create_failed: "向MySQL创建用户失败：{error}"
+  ldap_create_failed: "向LDAP创建用户失败：{error}"
+  mysql_add_group_relation_failed: "向MySQL添加用户到分组关系失败：{error}"
+  ldap_add_group_relation_failed: "向LDAP添加用户到分组关系失败：{error}"
+  ldap_update_failed: "在LDAP更新用户失败：{error}"
+  mysql_update_failed: "在MySQL更新用户失败：{error}"
+  mysql_remove_group_relation_failed: "在MySQL将用户从分组移除失败：{error}"
+  ldap_remove_group_relation_failed: "在LDAP将用户从分组移除失败：{error}"
+base:
+  email_not_found: 邮箱不存在,请检查邮箱是否正确
+  code_expired: 对不起，该验证码已超过5分钟有效期，请重新重置密码
+  code_invalid: 验证码错误，请检查邮箱中正确的验证码，如果点击多次发送验证码，请用最后一次生成的验证码来验证
+  reset_password_user_unavailable: 该用户已离职或者未同步在ldap，无法重置密码，如有疑问，请联系管理员
+  send_email_failed: "邮件发送失败: {error}"
+  email_query_failed: "通过邮箱查询用户失败{error}"
+  ldap_new_password_failed: "LDAP生成新密码失败{error}"
+user:
+  username_exists: 用户名已存在,请勿重复添加
+  mobile_exists: 手机号已存在,请勿重复添加
+  job_number_exists: 工号已存在,请勿重复添加
+  mail_exists: 邮箱已存在,请勿重复添加
+  password_encrypt_failed: 密码加密失败
+  password_decrypt_failed: 密码解密失败
+  password_min_length: 密码长度至少为{min}位
+  cannot_delete_self: 用户不能删除自己
+  not_found: 用户不存在
+  current_min_role_sort_failed: 获取当前登陆用户角色排序最小值失败
+  role_info_failed: 根据角色ID获取角色信息失败
+  cannot_create_higher_or_equal: 用户不能创建比自己等级高的或者相同等级的用户
+  department_info_failed: "根据部门ID获取部门信息失败{error}"
+  create_failed: "添加用户失败{error}"
+  list_failed: "获取用户列表失败：{error}"
+  count_failed: "获取用户总数失败：{error}"
+  cannot_change_self_role: 不能更改自己的角色
+  min_role_sort_by_id_failed: 根据用户ID获取用户角色排序最小值失败
+  cannot_update_higher_or_equal: 用户不能更新比自己角色等级高的或者相同等级的用户
+  update_failed: "更新用户失败{error}"
+  cannot_delete_higher: 用户不能删除比自己角色等级高的用户
+  info_failed: "获取用户信息失败: {error}"
+  ldap_delete_failed: "在LDAP删除用户失败{error}"
+  mysql_delete_failed: "在MySQL删除用户失败: {error}"
+  ldap_password_update_failed: "在LDAP更新密码失败{error}"
+  mysql_password_update_failed: "在MySQL更新密码失败: {error}"
+  mysql_query_failed: "在MySQL查询用户失败: {error}"
+  ldap_add_failed: "在LDAP添加用户失败{error}"
+  mysql_status_update_failed: "在MySQL更新用户状态失败: {error}"
+  current_info_failed: "获取当前用户信息失败: {error}"
+menu:
+  name_exists: 菜单名称已存在
+  create_failed: "创建记录失败: {error}"
+  update_failed: "更新记录失败: {error}"
+  delete_failed: "删除接口失败: {error}"
+  record_not_found: 该ID对应的记录不存在
+  record_get_failed: "获取记录失败: {error}"
+  count_failed: 获取菜单总数失败
+api:
+  create_failed: "创建接口失败: {error}"
+  list_failed: "获取接口列表失败: {error}"
+  count_failed: 获取接口总数失败
+  not_found: 接口不存在
+  update_failed: "更新接口失败: {error}"
+  delete_failed: "删除接口失败: {error}"
+operation_log:
+  list_failed: "获取操作日志列表失败: {error}"
+  count_failed: 获取操作日志总数失败
+  not_found: 该条记录不存在
+  delete_failed: "删除该条记录失败: {error}"
+  clean_failed: "清空操作日志失败: {error}"
+role:
+  name_exists: 该角色名已存在
+  not_found: 该角色名不存在
+  current_max_sort_failed: "获取当前用户最高角色等级失败: {error}"
+  no_update_permission: 当前用户没有权限更新角色
+  cannot_create_higher_or_equal: 不能创建比自己等级高或相同等级的角色
+  create_failed: "创建角色失败: {error}"
+  list_failed: "获取角色列表失败: {error}"
+  count_failed: 获取角色总数失败
+  info_not_found: 获取角色信息失败，未找到对应角色
+  cannot_update_higher_or_equal: 不能更新比自己角色等级高或相等的角色
+  cannot_set_higher_or_equal: 不能把角色等级更新得比当前用户的等级高或相同
+  update_failed: "更新角色失败: {error}"
+  keyword_policy_update_failed: 更新角色成功，但角色关键字关联的权限接口更新失败
+  keyword_policy_load_failed: 更新角色成功，但角色关键字关联角色的权限接口策略加载失败
+  no_role_info: 未能获取到角色信息
+  cannot_delete_higher_or_equal: 不能删除比自己角色等级高或相等的角色
+  delete_failed: "删除角色失败: {error}"
+  menu_list_failed: "获取角色的权限菜单失败: {error}"
+  resource_failed: "获取资源失败: {error}"
+  cannot_update_higher_or_equal_permissions: 不能更新比自己角色等级高或相等角色的权限菜单
+  current_user_menu_list_failed: "获取当前用户的可访问菜单列表失败: {error}"
+  no_menu_permission: "无权设置ID为{id}的菜单"
+  menu_all_list_failed: "获取菜单列表失败: {error}"
+  update_menus_failed: "更新角色的权限菜单失败: {error}"
+  api_info_failed: 根据接口ID获取接口信息失败
+  no_api_permission: "无权设置路径为{path},请求方式为{method}的接口"
+  update_apis_failed: 更新角色的权限接口失败
+group:
+  parent_info_failed: 获取父级组信息失败
+  dn_exists: 该分组对应DN已存在
+  ldap_create_failed: "向LDAP创建分组失败{error}"
+  mysql_create_failed: 向MySQL创建分组失败
+  add_user_failed: "添加用户到分组失败: {error}"
+  user_list_failed: "获取用户列表失败: {error}"
+  list_failed: "获取分组列表失败: {error}"
+  count_failed: 获取分组总数失败
+  not_found: 分组不存在
+  ldap_update_failed: "向LDAP更新分组失败：{error}"
+  mysql_update_failed: 向MySQL更新分组失败
+  some_not_found: 有分组不存在
+  has_children: 存在子分组，请先删除子分组，再执行该分组的删除操作！
+  ldap_delete_failed: "向LDAP删除分组失败：{error}"
+  delete_failed: "删除分组失败: {error}"
+  get_failed: "获取分组失败: {error}"
+  ou_cannot_add_user: ou类型的分组不能添加用户
+  ou_has_no_user: ou类型的分组内没有用户
+  ldap_add_user_failed: "向LDAP添加用户到分组失败{error}"
+  user_department_failed: "处理用户的部门数据失败:{error}"
+  mysql_user_update_failed: "在MySQL更新用户失败：{error}"
+  ldap_remove_user_failed: "将用户从ldap移除失败{error}"
+  mysql_remove_user_failed: "将用户从MySQL移除失败: {error}"
+field_relation:
+  exists: 对应平台的动态字段关系已存在，请勿重复添加
+  not_found: 对应平台的动态字段关系不存在
+  map_to_json_failed: "将map转成json失败: {error}"
+  create_failed: "创建动态字段关系失败: {error}"
+  list_failed: "字段动态关系: {error}"
+  update_failed: "更新动态字段关系失败: {error}"
+  delete_failed: "删除动态字段关系失败: {error}"
+legacy:
+  common:
+    current_user_failed: 获取当前登陆用户失败
+    resource_list_failed: "获取资源列表失败: {error}"
+    record_not_found: 该记录不存在
+  user:
+    some_not_found: 有用户不存在
+    not_found: 该用户不存在
+    old_password_incorrect: 原密码错误
+    old_password_parse_failed: 原密码解析失败
+    new_password_parse_failed: 新密码解析失败
+    already_active: 用户已经是在职状态
+    already_inactive: 用户已经是离职状态
+    only_admin_change_status: 只有管理员才能更改用户状态
+    list_failed: "获取用户列表失败: {error}"
+    count_failed: 获取用户总数失败
+    create_failed: "添加用户失败{error}"
+    update_failed: "更新用户失败{error}"
+    info_failed: "获取用户信息失败: {error}"
+    ldap_delete_failed: "在LDAP删除用户失败{error}"
+    ldap_add_failed: "在LDAP添加用户失败{error}"
+    ldap_password_update_failed: "在LDAP更新密码失败{error}"
+    mysql_delete_failed: "在MySQL删除用户失败: {error}"
+    mysql_password_update_failed: "在MySQL更新密码失败: {error}"
+    mysql_status_update_failed: "在MySQL更新用户状态失败: {error}"
+  api:
+    create_failed: "创建接口失败: {error}"
+    list_failed: "获取接口列表失败: {error}"
+    count_failed: 获取接口总数失败
+    not_found: 接口不存在
+    update_failed: "更新接口失败: {error}"
+    delete_failed: "删除接口失败: {error}"
+  role:
+    name_exists: 该角色名已存在
+    not_found: 该角色名不已存在
+    current_max_sort_failed: "获取当前用户最高角色等级失败: {error}"
+    no_update_permission: 当前用户没有权限更新角色
+    cannot_create_higher_or_equal: 不能创建比自己等级高或相同等级的角色
+    create_failed: "创建角色失败: {error}"
+    list_failed: "获取菜单列表失败: {error}"
+    info_failed: "获取角色信息失败: {error}"
+    cannot_update_higher_or_equal: 不能更新比自己角色等级高或相等的角色
+    cannot_set_higher_or_equal: 不能把角色等级更新得比当前用户的等级高或相同
+    update_failed: "更新角色失败: {error}"
+    no_role_info: 未能获取到角色信息
+    cannot_delete_higher_or_equal: 不能删除比自己角色等级高或相等的角色
+    delete_failed: "删除角色失败: {error}"
+    menu_list_failed: "获取角色的权限菜单失败: {error}"
+    count_failed: 获取角色总数失败
+  group:
+    parent_info_failed: 获取父级组信息失败
+    dn_exists: 该分组对应DN已存在
+    ldap_create_failed: "向LDAP创建分组失败{error}"
+    mysql_create_failed: 向MySQL创建分组失败
+    add_user_failed: "添加用户到分组失败: {error}"
+    list_failed: "获取分组列表失败: {error}"
+    count_failed: 获取分组总数失败
+    not_found: 分组不存在
+    ldap_update_failed: "向LDAP更新分组失败：{error}"
+    mysql_update_failed: 向MySQL更新分组失败
+    some_not_found: 有分组不存在
+    has_children: 存在子分组，请先删除子分组，再执行该分组的删除操作！
+    ldap_delete_failed: "向LDAP删除分组失败：{error}"
+    get_failed: "获取分组失败: {error}"
+    ou_cannot_add_user: ou类型的分组不能添加用户
+    ou_has_no_user: ou类型的分组内没有用户
+    ldap_add_user_failed: "向LDAP添加用户到分组失败{error}"
+    user_department_failed: "处理用户的部门数据失败:{error}"
+    mysql_user_update_failed: "在MySQL更新用户失败：{error}"
+    ldap_remove_user_failed: "将用户从ldap移除失败{error}"
+    mysql_remove_user_failed: "将用户从MySQL移除失败: {error}"
+  base:
+    email_query_failed: "通过邮箱查询用户失败{error}"
+    ldap_new_password_failed: "LDAP生成新密码失败{error}"
+  menu:
+    count_failed: 获取菜单总数失败
+  log:
+    count_failed: 获取日志总数失败
+builtin:
+  creator:
+    系统: 系统
+    system: 系统
+  role:
+    admin:
+      name: 管理员
+      remark: ""
+    user:
+      name: 普通用户
+      remark: ""
+    guest:
+      name: 访客
+      remark: ""
+  menu:
+    UserManage:
+      name: 人员管理
+      title: 人员管理
+    User:
+      name: 用户管理
+      title: 用户管理
+    Group:
+      name: 分组管理
+      title: 分组管理
+    FieldRelation:
+      name: 字段关系管理
+      title: 字段关系管理
+    System:
+      name: 系统管理
+      title: 系统管理
+    Role:
+      name: 角色管理
+      title: 角色管理
+    Menu:
+      name: 菜单管理
+      title: 菜单管理
+    Api:
+      name: 接口管理
+      title: 接口管理
+    Log:
+      name: 日志管理
+      title: 日志管理
+    OperationLog:
+      name: 操作日志
+      title: 操作日志
+  api:
+    category:
+      base: 基础管理
+      user: 用户管理
+      group: 分组管理
+      role: 角色管理
+      menu: 菜单管理
+      api: 接口管理
+      fieldrelation: 字段关系管理
+      log: 日志管理
+    remark:
+      get:
+        base_ping: 测试接口
+        base_encryptpwd: 加密密码
+        base_decryptpwd: 解密密码
+        base_config: 获取系统配置
+        base_version: 获取系统版本信息
+        base_dashboard: 获取系统首页展示数据
+        user_info: 获取当前登录用户信息
+        user_list: 获取用户列表
+        group_list: 获取分组列表
+        group_tree: 获取分组列表树
+        group_useringroup: 获取在分组内的用户列表
+        group_usernoingroup: 获取不在分组内的用户列表
+        role_list: 获取角色列表
+        role_getmenulist: 获取角色的权限菜单
+        role_getapilist: 获取角色的权限接口
+        menu_tree: 获取菜单树
+        menu_access_tree: 获取用户菜单树
+        api_list: 获取接口列表
+        api_tree: 获取接口树
+        fieldrelation_list: 获取字段动态关系列表
+        log_operation_list: 获取操作日志列表
+      post:
+        base_login: 用户登录
+        base_logout: 用户登出
+        base_refreshtoken: 刷新JWT令牌
+        base_sendcode: 给用户邮箱发送验证码
+        base_changepwd: 通过邮箱修改密码
+        user_changepwd: 更新用户登录密码
+        user_resetpassword: 重置用户密码
+        user_add: 创建用户
+        user_update: 更新用户
+        user_delete: 批量删除用户
+        user_changeuserstatus: 更改用户在职状态
+        user_syncdingtalkusers: 从钉钉拉取用户信息
+        user_syncwecomusers: 从企业微信拉取用户信息
+        user_syncfeishuusers: 从飞书拉取用户信息
+        user_syncopenldapusers: 从openldap拉取用户信息
+        user_syncsqlusers: 将数据库中的用户同步到Ldap
+        group_add: 创建分组
+        group_update: 更新分组
+        group_delete: 批量删除分组
+        group_adduser: 添加用户到分组
+        group_removeuser: 将用户从分组移出
+        group_syncdingtalkdepts: 从钉钉拉取部门信息
+        group_syncwecomdepts: 从企业微信拉取部门信息
+        group_syncfeishudepts: 从飞书拉取部门信息
+        group_syncopenldapdepts: 从openldap拉取部门信息
+        group_syncsqlgroups: 将数据库中的分组同步到Ldap
+        role_add: 创建角色
+        role_update: 更新角色
+        role_updatemenus: 更新角色的权限菜单
+        role_updateapis: 更新角色的权限接口
+        role_delete: 批量删除角色
+        menu_add: 创建菜单
+        menu_update: 更新菜单
+        menu_delete: 批量删除菜单
+        api_add: 创建接口
+        api_update: 更新接口
+        api_delete: 批量删除接口
+        fieldrelation_add: 创建字段动态关系
+        fieldrelation_update: 更新字段动态关系
+        fieldrelation_delete: 批量删除字段动态关系
+        log_operation_delete: 批量删除操作日志
+      delete:
+        log_operation_clean: 清空操作日志
+  group:
+    name:
+      openldap:
+        root: root
+      dingtalk:
+        dingtalkroot: 钉钉根部门
+      wecom:
+        wecomroot: 企业微信根部门
+      feishu:
+        feishuroot: 飞书根部门
+      platform:
+        group: 默认分组
+    remark:
+      openldap:
+        root: Base
+      dingtalk:
+        dingtalkroot: 钉钉根部门
+      wecom:
+        wecomroot: 企业微信根部门
+      feishu:
+        feishuroot: 飞书根部门
+      platform:
+        group: 默认分组

--- a/logic/a_logic.go
+++ b/logic/a_logic.go
@@ -7,6 +7,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -16,7 +17,7 @@ import (
 )
 
 var (
-	ReqAssertErr = tools.NewRspError(tools.SystemErr, fmt.Errorf("请求异常"))
+	ReqAssertErr = tools.NewRspI18nError(tools.SystemErr, "common.request_invalid", nil)
 
 	Api           = &ApiLogic{}
 	User          = &UserLogic{}
@@ -83,10 +84,10 @@ func CommonUpdateGroup(oldGroup, newGroup *model.Group) error {
 }
 
 // CommonAddUser 标准创建用户
-func CommonAddUser(user *model.User, groups []*model.Group) error {
+func CommonAddUser(user *model.User, groups []*model.Group, locale ...string) error {
 	// 用户信息的预置处理
 	if user.Nickname == "" {
-		user.Nickname = "佚名"
+		user.Nickname = "Anonymous"
 	}
 	if user.GivenName == "" {
 		user.GivenName = user.Nickname
@@ -106,13 +107,13 @@ func CommonAddUser(user *model.User, groups []*model.Group) error {
 		user.JobNumber = "0000"
 	}
 	if user.Departments == "" {
-		user.Departments = "默认:研发中心"
+		user.Departments = "Default: R&D Center"
 	}
 	if user.Position == "" {
-		user.Position = "默认:打工人"
+		user.Position = "Default: Staff"
 	}
 	if user.PostalAddress == "" {
-		user.PostalAddress = "默认:地球"
+		user.PostalAddress = "Default: Earth"
 	}
 	if user.Mobile == "" {
 		user.Mobile = generateMobile()
@@ -121,17 +122,17 @@ func CommonAddUser(user *model.User, groups []*model.Group) error {
 	// 先将用户添加到MySQL
 	err := isql.User.Add(user)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("%s", "向MySQL创建用户失败："+err.Error()))
+		return tools.NewMySqlI18nError("common_user.mysql_create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 发送用户创建成功通知邮件
-	if err := tools.SendUserCreationNotification(user.Username, user.Nickname, user.Mail, tools.NewParPasswd(user.Password)); err != nil {
+	if err := tools.SendUserCreationNotificationI18n(user.Username, user.Nickname, user.Mail, tools.NewParPasswd(user.Password), firstLocale(locale)); err != nil {
 		common.Log.Warnf("发送用户创建通知邮件失败，用户: %s, 邮箱: %s, 错误: %v", user.Username, user.Mail, err)
 	}
 	// 再将用户添加到ldap
 	err = ildap.User.Add(user)
 	if err != nil {
-		return tools.NewLdapError(fmt.Errorf("%s", "AddUser向LDAP创建用户失败："+err.Error()))
+		return tools.NewLdapI18nError("common_user.ldap_create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 处理用户归属的组
@@ -142,15 +143,22 @@ func CommonAddUser(user *model.User, groups []*model.Group) error {
 		// 先将用户和部门信息维护到MySQL
 		err := isql.Group.AddUserToGroup(group, []model.User{*user})
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "向MySQL添加用户到分组关系失败："+err.Error()))
+			return tools.NewMySqlI18nError("common_user.mysql_add_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 		//根据选择的部门，添加到部门内
 		err = ildap.Group.AddUserToGroup(group.GroupDN, user.UserDN)
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "向Ldap添加用户到分组关系失败："+err.Error()))
+			return tools.NewLdapI18nError("common_user.ldap_add_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 	return nil
+}
+
+func firstLocale(locales []string) string {
+	if len(locales) == 0 {
+		return ""
+	}
+	return locales[0]
 }
 
 // CommonUpdateUser 标准更新用户
@@ -162,12 +170,12 @@ func CommonUpdateUser(oldUser, newUser *model.User, groupId []uint) error {
 
 	err := ildap.User.Update(oldUser.Username, newUser)
 	if err != nil {
-		return tools.NewLdapError(fmt.Errorf("%s", "在LDAP更新用户失败："+err.Error()))
+		return tools.NewLdapI18nError("common_user.ldap_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	err = isql.User.Update(newUser)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("%s", "在MySQL更新用户失败："+err.Error()))
+		return tools.NewMySqlI18nError("common_user.mysql_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	//判断部门信息是否有变化有变化则更新相应的数据库
@@ -177,7 +185,7 @@ func CommonUpdateUser(oldUser, newUser *model.User, groupId []uint) error {
 	// 先处理添加的部门
 	addgroups, err := isql.Group.GetGroupByIds(addDeptIds)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+		return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 	}
 	for _, group := range addgroups {
 		if group.GroupDN[:3] == "ou=" {
@@ -186,19 +194,19 @@ func CommonUpdateUser(oldUser, newUser *model.User, groupId []uint) error {
 		// 先将用户和部门信息维护到MySQL
 		err := isql.Group.AddUserToGroup(group, []model.User{*newUser})
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "向MySQL添加用户到分组关系失败："+err.Error()))
+			return tools.NewMySqlI18nError("common_user.mysql_add_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 		//根据选择的部门，添加到部门内
 		err = ildap.Group.AddUserToGroup(group.GroupDN, newUser.UserDN)
 		if err != nil {
-			return tools.NewLdapError(fmt.Errorf("%s", "向Ldap添加用户到分组关系失败："+err.Error()))
+			return tools.NewLdapI18nError("common_user.ldap_add_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
 	// 再处理删除的部门
 	removegroups, err := isql.Group.GetGroupByIds(removeDeptIds)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+		return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 	}
 	for _, group := range removegroups {
 		if group.GroupDN[:3] == "ou=" {
@@ -206,11 +214,11 @@ func CommonUpdateUser(oldUser, newUser *model.User, groupId []uint) error {
 		}
 		err := isql.Group.RemoveUserFromGroup(group, []model.User{*newUser})
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "在MySQL将用户从分组移除失败："+err.Error()))
+			return tools.NewMySqlI18nError("common_user.mysql_remove_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 		err = ildap.Group.RemoveUserFromGroup(group.GroupDN, newUser.UserDN)
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "在ldap将用户从分组移除失败："+err.Error()))
+			return tools.NewLdapI18nError("common_user.ldap_remove_group_relation_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 	return nil
@@ -322,7 +330,7 @@ func ConvertUserData(flag string, remoteData []map[string]any) (users []*model.U
 	for _, staff := range remoteData {
 		groupIds, err := isql.Group.DeptIdsToGroupIds(staff["department_ids"].([]string))
 		if err != nil {
-			return nil, tools.NewMySqlError(fmt.Errorf("将部门ids转换为内部部门id失败：%s", err.Error()))
+			return nil, tools.NewMySqlI18nError("sync.dept_ids_convert_failed", i18n.Args{"error": err.Error()})
 		}
 		user, err := BuildUserData(flag, staff)
 		if err != nil {

--- a/logic/api_logic.go
+++ b/logic/api_logic.go
@@ -1,11 +1,10 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -26,7 +25,7 @@ func (l ApiLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 获取当前用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户信息失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	api := model.Api{
@@ -40,7 +39,7 @@ func (l ApiLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 创建接口
 	err = isql.Api.Add(&api)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("创建接口失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("api.create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -57,16 +56,17 @@ func (l ApiLogic) List(c *gin.Context, req any) (data any, rspError any) {
 	// 获取数据列表
 	apis, err := isql.Api.List(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("api.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]model.Api, 0)
 	for _, api := range apis {
+		localizeApi(c, api)
 		rets = append(rets, *api)
 	}
 	count, err := isql.Api.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口总数失败"))
+		return nil, tools.NewMySqlI18nError("api.count_failed", nil)
 	}
 
 	return response.ApiListRsp{
@@ -86,8 +86,9 @@ func (l ApiLogic) GetTree(c *gin.Context, req any) (data any, rspError any) {
 
 	apis, err := isql.Api.ListAll()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
+	localizeApis(c, apis)
 
 	// 获取所有的分类
 	var categoryList []string
@@ -101,10 +102,12 @@ func (l ApiLogic) GetTree(c *gin.Context, req any) (data any, rspError any) {
 
 	for i, category := range categoryUniq {
 		apiTree[i] = &response.ApiTreeRsp{
-			ID:       -i,
-			Remark:   category,
-			Category: category,
-			Children: nil,
+			ID:              -i,
+			Remark:          localizeBuiltinValue(c, "api.category", category),
+			RemarkDisplay:   localizeBuiltinValue(c, "api.category", category),
+			Category:        category,
+			CategoryDisplay: localizeBuiltinValue(c, "api.category", category),
+			Children:        nil,
 		}
 		for _, api := range apis {
 			if category == api.Category {
@@ -126,13 +129,13 @@ func (l ApiLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	filter := tools.H{"id": int(r.ID)}
 	if !isql.Api.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("接口不存在"))
+		return nil, tools.NewMySqlI18nError("api.not_found", nil)
 	}
 
 	// 获取当前登陆用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	oldData := new(model.Api)
@@ -151,7 +154,7 @@ func (l ApiLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 	}
 	err = isql.Api.Update(&api)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("更新接口失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("api.update_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -167,13 +170,13 @@ func (l ApiLogic) Delete(c *gin.Context, req any) (data any, rspError any) {
 	for _, id := range r.ApiIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.Api.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("接口不存在"))
+			return nil, tools.NewMySqlI18nError("api.not_found", nil)
 		}
 	}
 	// 删除接口
 	err := isql.Api.Delete(r.ApiIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除接口失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("api.delete_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }

--- a/logic/base_logic.go
+++ b/logic/base_logic.go
@@ -1,12 +1,11 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/public/version"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
@@ -28,14 +27,14 @@ func (l BaseLogic) SendCode(c *gin.Context, req any) (data any, rspError any) {
 	user := new(model.User)
 	err := isql.User.Find(tools.H{"mail": r.Mail}, user)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "通过邮箱查询用户失败"+err.Error()))
+		return nil, tools.NewMySqlI18nError("base.email_query_failed", i18n.Args{"error": err.Error()})
 	}
 	if user.Status != 1 || user.SyncState != 1 {
-		return nil, tools.NewMySqlError(fmt.Errorf("该用户已离职或者未同步在ldap，无法重置密码，如有疑问，请联系管理员"))
+		return nil, tools.NewMySqlI18nError("base.reset_password_user_unavailable", nil)
 	}
-	err = tools.SendCode([]string{r.Mail})
+	err = tools.SendCodeI18n([]string{r.Mail}, i18n.LocaleFromContext(c))
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "邮件发送失败"+err.Error()))
+		return nil, tools.NewLdapI18nError("base.send_email_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -50,38 +49,38 @@ func (l BaseLogic) ChangePwd(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 	// 判断邮箱是否正确
 	if !isql.User.Exist(tools.H{"mail": r.Mail}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("邮箱不存在,请检查邮箱是否正确"))
+		return nil, tools.NewValidatorI18nError("base.email_not_found", nil)
 	}
 	// 判断验证码是否过期
 	cacheCode, ok := tools.VerificationCodeCache.Get(r.Mail)
 	if !ok {
-		return nil, tools.NewValidatorError(fmt.Errorf("对不起，该验证码已超过5分钟有效期，请重新重新密码"))
+		return nil, tools.NewValidatorI18nError("base.code_expired", nil)
 	}
 	// 判断验证码是否正确
 	if cacheCode != r.Code {
-		return nil, tools.NewValidatorError(fmt.Errorf("验证码错误，请检查邮箱中正确的验证码，如果点击多次发送验证码，请用最后一次生成的验证码来验证"))
+		return nil, tools.NewValidatorI18nError("base.code_invalid", nil)
 	}
 
 	user := new(model.User)
 	err := isql.User.Find(tools.H{"mail": r.Mail}, user)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "通过邮箱查询用户失败"+err.Error()))
+		return nil, tools.NewMySqlI18nError("base.email_query_failed", i18n.Args{"error": err.Error()})
 	}
 
 	newpass, err := ildap.User.NewPwd(user.Username)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "LDAP生成新密码失败"+err.Error()))
+		return nil, tools.NewLdapI18nError("base.ldap_new_password_failed", i18n.Args{"error": err.Error()})
 	}
 
-	err = tools.SendMail([]string{user.Mail}, newpass)
+	err = tools.SendMailI18n([]string{user.Mail}, newpass, i18n.LocaleFromContext(c))
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "邮件发送失败"+err.Error()))
+		return nil, tools.NewLdapI18nError("base.send_email_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 更新数据库密码
 	err = isql.User.ChangePwd(user.Username, tools.NewGenPasswd(newpass))
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL更新密码失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_password_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -97,27 +96,27 @@ func (l BaseLogic) Dashboard(c *gin.Context, req any) (data any, rspError any) {
 
 	userCount, err := isql.User.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取用户总数失败"))
+		return nil, tools.NewMySqlI18nError("user.count_failed", i18n.Args{"error": err.Error()})
 	}
 	groupCount, err := isql.Group.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组总数失败"))
+		return nil, tools.NewMySqlI18nError("group.count_failed", nil)
 	}
 	roleCount, err := isql.Role.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取角色总数失败"))
+		return nil, tools.NewMySqlI18nError("role.count_failed", nil)
 	}
 	menuCount, err := isql.Menu.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取菜单总数失败"))
+		return nil, tools.NewMySqlI18nError("menu.count_failed", nil)
 	}
 	apiCount, err := isql.Api.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口总数失败"))
+		return nil, tools.NewMySqlI18nError("api.count_failed", nil)
 	}
 	logCount, err := isql.OperationLog.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取日志总数失败"))
+		return nil, tools.NewMySqlI18nError("operation_log.count_failed", nil)
 	}
 
 	rst := make([]*response.DashboardList, 0)
@@ -125,42 +124,42 @@ func (l BaseLogic) Dashboard(c *gin.Context, req any) (data any, rspError any) {
 	rst = append(rst,
 		&response.DashboardList{
 			DataType:  "user",
-			DataName:  "用户",
+			DataName:  i18n.TC(c, "dashboard.user", nil),
 			DataCount: userCount,
 			Icon:      "people",
 			Path:      "#/personnel/user",
 		},
 		&response.DashboardList{
 			DataType:  "group",
-			DataName:  "分组",
+			DataName:  i18n.TC(c, "dashboard.group", nil),
 			DataCount: groupCount,
 			Icon:      "peoples",
 			Path:      "#/personnel/group",
 		},
 		&response.DashboardList{
 			DataType:  "role",
-			DataName:  "角色",
+			DataName:  i18n.TC(c, "dashboard.role", nil),
 			DataCount: roleCount,
 			Icon:      "eye-open",
 			Path:      "#/system/role",
 		},
 		&response.DashboardList{
 			DataType:  "menu",
-			DataName:  "菜单",
+			DataName:  i18n.TC(c, "dashboard.menu", nil),
 			DataCount: menuCount,
 			Icon:      "tree-table",
 			Path:      "#/system/menu",
 		},
 		&response.DashboardList{
 			DataType:  "api",
-			DataName:  "接口",
+			DataName:  i18n.TC(c, "dashboard.api", nil),
 			DataCount: apiCount,
 			Icon:      "tree",
 			Path:      "#/system/api",
 		},
 		&response.DashboardList{
 			DataType:  "log",
-			DataName:  "日志",
+			DataName:  i18n.TC(c, "dashboard.log", nil),
 			DataCount: logCount,
 			Icon:      "documentation",
 			Path:      "#/log/operation-log",
@@ -178,7 +177,11 @@ func (l BaseLogic) EncryptPasswd(c *gin.Context, req any) (data any, rspError an
 	}
 	_ = c
 
-	return tools.NewGenPasswd(r.Passwd), nil
+	passwd, err := tools.RSAEncrypt([]byte(r.Passwd), config.Conf.System.RSAPublicBytes)
+	if err != nil {
+		return nil, tools.NewValidatorI18nError("user.password_encrypt_failed", nil)
+	}
+	return string(passwd), nil
 }
 
 // DecryptPasswd
@@ -189,7 +192,11 @@ func (l BaseLogic) DecryptPasswd(c *gin.Context, req any) (data any, rspError an
 	}
 	_ = c
 
-	return tools.NewParPasswd(r.Passwd), nil
+	passwd, err := tools.RSADecrypt([]byte(r.Passwd), config.Conf.System.RSAPrivateBytes)
+	if err != nil {
+		return nil, tools.NewValidatorI18nError("user.password_decrypt_failed", nil)
+	}
+	return string(passwd), nil
 }
 
 // GetConfig 获取系统配置

--- a/logic/builtin_i18n.go
+++ b/logic/builtin_i18n.go
@@ -1,0 +1,104 @@
+package logic
+
+import (
+	"strings"
+
+	"github.com/eryajf/go-ldap-admin/model"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+
+	"github.com/gin-gonic/gin"
+)
+
+func localizeMenu(c *gin.Context, menu *model.Menu) {
+	if menu == nil {
+		return
+	}
+	menu.NameDisplay = localizeBuiltin(c, "builtin.menu."+menu.Name+".name", menu.Name)
+	menu.TitleDisplay = localizeBuiltin(c, "builtin.menu."+menu.Name+".title", menu.Title)
+	menu.CreatorDisplay = localizeBuiltinValue(c, "creator", menu.Creator)
+	for _, child := range menu.Children {
+		localizeMenu(c, child)
+	}
+}
+
+func localizeMenus(c *gin.Context, menus []*model.Menu) {
+	for _, menu := range menus {
+		localizeMenu(c, menu)
+	}
+}
+
+func localizeApi(c *gin.Context, api *model.Api) {
+	if api == nil {
+		return
+	}
+	api.CategoryDisplay = localizeBuiltinValue(c, "api.category", api.Category)
+	api.RemarkDisplay = localizeBuiltin(c, "builtin.api.remark."+apiRemarkKey(api.Method, api.Path), api.Remark)
+	api.CreatorDisplay = localizeBuiltinValue(c, "creator", api.Creator)
+}
+
+func localizeApis(c *gin.Context, apis []*model.Api) {
+	for _, api := range apis {
+		localizeApi(c, api)
+	}
+}
+
+func localizeRole(c *gin.Context, role *model.Role) {
+	if role == nil {
+		return
+	}
+	role.NameDisplay = localizeBuiltin(c, "builtin.role."+role.Keyword+".name", role.Name)
+	role.RemarkDisplay = localizeBuiltin(c, "builtin.role."+role.Keyword+".remark", role.Remark)
+	role.CreatorDisplay = localizeBuiltinValue(c, "creator", role.Creator)
+	for _, menu := range role.Menus {
+		localizeMenu(c, menu)
+	}
+}
+
+func localizeRoles(c *gin.Context, roles []*model.Role) {
+	for _, role := range roles {
+		localizeRole(c, role)
+	}
+}
+
+func localizeGroup(c *gin.Context, group *model.Group) {
+	if group == nil {
+		return
+	}
+	group.GroupNameDisplay = localizeBuiltin(c, "builtin.group.name."+group.Source+"."+group.GroupName, group.GroupName)
+	group.RemarkDisplay = localizeBuiltin(c, "builtin.group.remark."+group.Source+"."+group.GroupName, group.Remark)
+	group.CreatorDisplay = localizeBuiltinValue(c, "creator", group.Creator)
+	for _, child := range group.Children {
+		localizeGroup(c, child)
+	}
+}
+
+func localizeGroups(c *gin.Context, groups []*model.Group) {
+	for _, group := range groups {
+		localizeGroup(c, group)
+	}
+}
+
+func localizeBuiltinValue(c *gin.Context, group string, value string) string {
+	if value == "" {
+		return ""
+	}
+	return localizeBuiltin(c, "builtin."+group+"."+value, value)
+}
+
+func localizeBuiltin(c *gin.Context, key string, fallback string) string {
+	if key == "" {
+		return fallback
+	}
+	msg := i18n.TC(c, key, nil)
+	if msg == key {
+		return fallback
+	}
+	return msg
+}
+
+func apiRemarkKey(method string, path string) string {
+	key := strings.ToLower(strings.TrimSpace(method)) + "." + strings.Trim(strings.TrimSpace(path), "/")
+	replacer := strings.NewReplacer("/", "_", "-", "_")
+	key = replacer.Replace(key)
+	return key
+}

--- a/logic/dingtalk_logic.go
+++ b/logic/dingtalk_logic.go
@@ -1,7 +1,6 @@
 package logic
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/dingtalk"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -25,18 +25,18 @@ func (d *DingTalkLogic) SyncDingTalkDepts(c *gin.Context, req any) (data any, rs
 	if err != nil {
 		errMsg := fmt.Sprintf("获取钉钉部门列表失败：%s", err.Error())
 		common.Log.Errorf("SyncDingTalkDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_list_failed", i18n.Args{"provider": "DingTalk", "error": err.Error()})
 	}
 	depts, err := ConvertDeptData(config.Conf.DingTalk.Flag, deptSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换钉钉部门数据失败：%s", err.Error())
 		common.Log.Errorf("SyncDingTalkDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_convert_failed", i18n.Args{"provider": "DingTalk", "error": err.Error()})
 	}
 	if len(depts) == 0 {
 		errMsg := "获取到的部门数量为0"
 		common.Log.Errorf("SyncDingTalkDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_depts", nil)
 	}
 
 	// 2.将远程数据转换成树
@@ -61,14 +61,14 @@ func (d DingTalkLogic) addDepts(depts []*model.Group) error {
 		if err != nil {
 			errMsg := fmt.Sprintf("DsyncDingTalkDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
 			common.Log.Errorf("%s", errMsg)
-			return tools.NewOperationError(errors.New(errMsg))
+			return tools.NewOperationI18nError("sync.dept_add_failed", i18n.Args{"dept": dept.GroupName, "error": err.Error()})
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
 				errMsg := fmt.Sprintf("DsyncDingTalkDepts添加子部门失败: %s", err.Error())
 				common.Log.Errorf("%s", errMsg)
-				return tools.NewOperationError(errors.New(errMsg))
+				return tools.NewOperationI18nError("sync.child_dept_add_failed", i18n.Args{"error": err.Error()})
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func (d DingTalkLogic) AddDepts(group *model.Group) error {
 	parentGroup := new(model.Group)
 	err := isql.Group.Find(tools.H{"source_dept_id": group.SourceDeptParentId}, parentGroup) // 查询当前分组父ID在MySQL中的数据信息
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("查询父级部门失败：%s", err.Error()))
+		return tools.NewMySqlI18nError("sync.parent_dept_query_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 此时的 group 已经附带了Build后动态关联好的字段，接下来将一些确定性的其他字段值添加上，就可以创建这个分组了
@@ -93,7 +93,7 @@ func (d DingTalkLogic) AddDepts(group *model.Group) error {
 	if !isql.Group.Exist(tools.H{"group_dn": group.GroupDN}) { // 判断当前部门是否已落库
 		err = CommonAddGroup(group)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加部门: %s, 失败: %s", group.GroupName, err.Error()))
+			return tools.NewOperationI18nError("sync.add_dept_failed", i18n.Args{"dept": group.GroupName, "error": err.Error()})
 		}
 	}
 	return nil
@@ -106,18 +106,18 @@ func (d DingTalkLogic) SyncDingTalkUsers(c *gin.Context, req any) (data any, rsp
 	if err != nil {
 		errMsg := fmt.Sprintf("获取钉钉用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_list_failed", i18n.Args{"provider": "DingTalk", "error": err.Error()})
 	}
 	staffs, err := ConvertUserData(config.Conf.DingTalk.Flag, staffSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换钉钉用户数据失败：%s", err.Error())
 		common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_convert_failed", i18n.Args{"provider": "DingTalk", "error": err.Error()})
 	}
 	if len(staffs) == 0 {
 		errMsg := "获取到的用户数量为0"
 		common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_users", nil)
 	}
 	// 2.遍历用户，开始写入
 	for i, staff := range staffs {
@@ -126,7 +126,7 @@ func (d DingTalkLogic) SyncDingTalkUsers(c *gin.Context, req any) (data any, rsp
 		if err != nil {
 			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Username, err.Error())
 			common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-			return nil, tools.NewOperationError(errors.New(errMsg))
+			return nil, tools.NewOperationI18nError("sync.user_write_failed", i18n.Args{"username": staff.Username, "error": err.Error()})
 		}
 		common.Log.Infof("SyncDingTalkUsers: 成功同步用户[%s] (%d/%d)", staff.Username, i+1, len(staffs))
 	}
@@ -142,7 +142,7 @@ func (d DingTalkLogic) SyncDingTalkUsers(c *gin.Context, req any) (data any, rsp
 	if err != nil {
 		errMsg := fmt.Sprintf("获取钉钉离职用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.leave_user_list_failed", i18n.Args{"provider": "DingTalk", "error": err.Error()})
 	}
 
 	// 4.遍历id，开始处理
@@ -158,21 +158,21 @@ func (d DingTalkLogic) SyncDingTalkUsers(c *gin.Context, req any) (data any, rsp
 			if err != nil {
 				errMsg := fmt.Sprintf("在MySQL查询离职用户[%s]失败: %s", uid, err.Error())
 				common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-				return nil, tools.NewMySqlError(errors.New(errMsg))
+				return nil, tools.NewMySqlI18nError("sync.leave_user_query_failed", i18n.Args{"username": uid, "error": err.Error()})
 			}
 			// 先从ldap删除用户
 			err = ildap.User.Delete(user.UserDN)
 			if err != nil {
 				errMsg := fmt.Sprintf("在LDAP删除离职用户[%s]失败: %s", user.Username, err.Error())
 				common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-				return nil, tools.NewLdapError(errors.New(errMsg))
+				return nil, tools.NewLdapI18nError("sync.leave_user_ldap_delete_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 			}
 			// 然后更新MySQL中用户状态
 			err = isql.User.ChangeStatus(int(user.ID), 2)
 			if err != nil {
 				errMsg := fmt.Sprintf("在MySQL更新离职用户[%s]状态失败: %s", user.Username, err.Error())
 				common.Log.Errorf("SyncDingTalkUsers: %s", errMsg)
-				return nil, tools.NewMySqlError(errors.New(errMsg))
+				return nil, tools.NewMySqlI18nError("sync.leave_user_status_update_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 			}
 			processedCount++
 			common.Log.Infof("SyncDingTalkUsers: 成功处理离职用户[%s]", user.Username)
@@ -188,7 +188,7 @@ func (d DingTalkLogic) AddUsers(user *model.User) error {
 	// 根据角色id获取角色
 	roles, err := isql.Role.GetRolesByIds([]uint{2}) // 默认添加为普通用户角色
 	if err != nil {
-		return tools.NewValidatorError(fmt.Errorf("根据角色ID获取角色信息失败:%s", err.Error()))
+		return tools.NewValidatorI18nError("sync.role_info_failed", i18n.Args{"error": err.Error()})
 	}
 	user.Roles = roles
 	user.Creator = "system"
@@ -201,7 +201,7 @@ func (d DingTalkLogic) AddUsers(user *model.User) error {
 		// 获取用户将要添加的分组
 		groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+			return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 		}
 		var deptTmp string
 		for _, group := range groups {
@@ -212,7 +212,7 @@ func (d DingTalkLogic) AddUsers(user *model.User) error {
 		// 新增用户
 		err = CommonAddUser(user, groups)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加用户: %s, 失败: %s", user.Username, err.Error()))
+			return tools.NewOperationI18nError("sync.add_user_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 		}
 	} else {
 		if config.Conf.DingTalk.IsUpdateSyncd {
@@ -225,7 +225,7 @@ func (d DingTalkLogic) AddUsers(user *model.User) error {
 			// 获取用户将要添加的分组
 			groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 			if err != nil {
-				return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+				return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 			}
 			var deptTmp string
 			for _, group := range groups {

--- a/logic/feishu_logic.go
+++ b/logic/feishu_logic.go
@@ -1,7 +1,6 @@
 package logic
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/feishu"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -25,18 +25,18 @@ func (d *FeiShuLogic) SyncFeiShuDepts(c *gin.Context, req any) (data any, rspErr
 	if err != nil {
 		errMsg := fmt.Sprintf("获取飞书部门列表失败：%s", err.Error())
 		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_list_failed", i18n.Args{"provider": "Feishu", "error": err.Error()})
 	}
 	depts, err := ConvertDeptData(config.Conf.FeiShu.Flag, deptSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换飞书部门数据失败：%s", err.Error())
 		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_convert_failed", i18n.Args{"provider": "Feishu", "error": err.Error()})
 	}
 	if len(depts) == 0 {
 		errMsg := "获取到的部门数量为0"
 		common.Log.Errorf("SyncFeiShuDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_depts", nil)
 	}
 
 	// 2.将远程数据转换成树
@@ -61,14 +61,14 @@ func (d FeiShuLogic) addDepts(depts []*model.Group) error {
 		if err != nil {
 			errMsg := fmt.Sprintf("DsyncFeiShuDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
 			common.Log.Errorf("%s", errMsg)
-			return tools.NewOperationError(errors.New(errMsg))
+			return tools.NewOperationI18nError("sync.dept_add_failed", i18n.Args{"dept": dept.GroupName, "error": err.Error()})
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
 				errMsg := fmt.Sprintf("DsyncFeiShuDepts添加子部门失败: %s", err.Error())
 				common.Log.Errorf("%s", errMsg)
-				return tools.NewOperationError(errors.New(errMsg))
+				return tools.NewOperationI18nError("sync.child_dept_add_failed", i18n.Args{"error": err.Error()})
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func (d FeiShuLogic) AddDepts(group *model.Group) error {
 	parentGroup := new(model.Group)
 	err := isql.Group.Find(tools.H{"source_dept_id": group.SourceDeptParentId}, parentGroup)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("查询父级部门失败：%s", err.Error()))
+		return tools.NewMySqlI18nError("sync.parent_dept_query_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 此时的 group 已经附带了Build后动态关联好的字段，接下来将一些确定性的其他字段值添加上，就可以创建这个分组了
@@ -94,7 +94,7 @@ func (d FeiShuLogic) AddDepts(group *model.Group) error {
 	if !isql.Group.Exist(tools.H{"group_dn": group.GroupDN}) {
 		err = CommonAddGroup(group)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加部门: %s, 失败: %s", group.GroupName, err.Error()))
+			return tools.NewOperationI18nError("sync.add_dept_failed", i18n.Args{"dept": group.GroupName, "error": err.Error()})
 		}
 	}
 	return nil
@@ -107,18 +107,18 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req any) (data any, rspErro
 	if err != nil {
 		errMsg := fmt.Sprintf("获取飞书用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_list_failed", i18n.Args{"provider": "Feishu", "error": err.Error()})
 	}
 	staffs, err := ConvertUserData(config.Conf.FeiShu.Flag, staffSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换飞书用户数据失败：%s", err.Error())
 		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_convert_failed", i18n.Args{"provider": "Feishu", "error": err.Error()})
 	}
 	if len(staffs) == 0 {
 		errMsg := "获取到的用户数量为0"
 		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_users", nil)
 	}
 	// 2.遍历用户，开始写入
 	for i, staff := range staffs {
@@ -127,7 +127,7 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req any) (data any, rspErro
 		if err != nil {
 			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Username, err.Error())
 			common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-			return nil, tools.NewOperationError(errors.New(errMsg))
+			return nil, tools.NewOperationI18nError("sync.user_write_failed", i18n.Args{"username": staff.Username, "error": err.Error()})
 		}
 		common.Log.Infof("SyncFeiShuUsers: 成功同步用户[%s] (%d/%d)", staff.Username, i+1, len(staffs))
 	}
@@ -137,7 +137,7 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req any) (data any, rspErro
 	if err != nil {
 		errMsg := fmt.Sprintf("获取飞书离职用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.leave_user_list_failed", i18n.Args{"provider": "Feishu", "error": err.Error()})
 	}
 	// 4.遍历id，开始处理
 	processedCount := 0
@@ -152,21 +152,21 @@ func (d FeiShuLogic) SyncFeiShuUsers(c *gin.Context, req any) (data any, rspErro
 			if err != nil {
 				errMsg := fmt.Sprintf("在MySQL查询离职用户[%s]失败: %s", uid, err.Error())
 				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-				return nil, tools.NewMySqlError(errors.New(errMsg))
+				return nil, tools.NewMySqlI18nError("sync.leave_user_query_failed", i18n.Args{"username": uid, "error": err.Error()})
 			}
 			// 先从ldap删除用户
 			err = ildap.User.Delete(user.UserDN)
 			if err != nil {
 				errMsg := fmt.Sprintf("在LDAP删除离职用户[%s]失败: %s", user.Username, err.Error())
 				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-				return nil, tools.NewLdapError(errors.New(errMsg))
+				return nil, tools.NewLdapI18nError("sync.leave_user_ldap_delete_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 			}
 			// 然后更新MySQL中用户状态
 			err = isql.User.ChangeStatus(int(user.ID), 2)
 			if err != nil {
 				errMsg := fmt.Sprintf("在MySQL更新离职用户[%s]状态失败: %s", user.Username, err.Error())
 				common.Log.Errorf("SyncFeiShuUsers: %s", errMsg)
-				return nil, tools.NewMySqlError(errors.New(errMsg))
+				return nil, tools.NewMySqlI18nError("sync.leave_user_status_update_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 			}
 			processedCount++
 			common.Log.Infof("SyncFeiShuUsers: 成功处理离职用户[%s]", user.Username)
@@ -182,7 +182,7 @@ func (d FeiShuLogic) AddUsers(user *model.User) error {
 	// 根据角色id获取角色
 	roles, err := isql.Role.GetRolesByIds([]uint{2})
 	if err != nil {
-		return tools.NewValidatorError(fmt.Errorf("根据角色ID获取角色信息失败:%s", err.Error()))
+		return tools.NewValidatorI18nError("sync.role_info_failed", i18n.Args{"error": err.Error()})
 	}
 	user.Roles = roles
 	user.Creator = "system"
@@ -195,7 +195,7 @@ func (d FeiShuLogic) AddUsers(user *model.User) error {
 		// 获取用户将要添加的分组
 		groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+			return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 		}
 		var deptTmp string
 		for _, group := range groups {
@@ -206,7 +206,7 @@ func (d FeiShuLogic) AddUsers(user *model.User) error {
 		// 添加用户
 		err = CommonAddUser(user, groups)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加用户: %s, 失败: %s", user.Username, err.Error()))
+			return tools.NewOperationI18nError("sync.add_user_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 		}
 	} else {
 		// 此处逻辑未经实际验证，如在使用中有问题，请反馈
@@ -220,7 +220,7 @@ func (d FeiShuLogic) AddUsers(user *model.User) error {
 			// 获取用户将要添加的分组
 			groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 			if err != nil {
-				return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+				return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 			}
 			var deptTmp string
 			for _, group := range groups {

--- a/logic/field_relation_logic.go
+++ b/logic/field_relation_logic.go
@@ -1,10 +1,9 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 	"gorm.io/datatypes"
@@ -23,12 +22,12 @@ func (l FieldRelationLogic) Add(c *gin.Context, req any) (data any, rspError any
 	_ = c
 
 	if isql.FieldRelation.Exist(tools.H{"flag": r.Flag}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("对应平台的动态字段关系已存在，请勿重复添加"))
+		return nil, tools.NewValidatorI18nError("field_relation.exists", nil)
 	}
 
 	attr, err := tools.MapToJson(r.Attributes)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("将map转成json失败: %s", err.Error()))
+		return nil, tools.NewOperationI18nError("field_relation.map_to_json_failed", i18n.Args{"error": err.Error()})
 	}
 
 	frObj := model.FieldRelation{
@@ -39,7 +38,7 @@ func (l FieldRelationLogic) Add(c *gin.Context, req any) (data any, rspError any
 	// 创建接口
 	err = isql.FieldRelation.Add(&frObj)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("创建动态字段关系失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("field_relation.create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -56,7 +55,7 @@ func (l FieldRelationLogic) List(c *gin.Context, req any) (data any, rspError an
 	// 获取数据列表
 	frs, err := isql.FieldRelation.List()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("字段动态关系: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("field_relation.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return frs, nil
@@ -73,7 +72,7 @@ func (l FieldRelationLogic) Update(c *gin.Context, req any) (data any, rspError 
 	filter := tools.H{"flag": r.Flag}
 
 	if !isql.FieldRelation.Exist(filter) {
-		return nil, tools.NewValidatorError(fmt.Errorf("对应平台的动态字段关系不存在"))
+		return nil, tools.NewValidatorI18nError("field_relation.not_found", nil)
 	}
 
 	oldData := new(model.FieldRelation)
@@ -84,7 +83,7 @@ func (l FieldRelationLogic) Update(c *gin.Context, req any) (data any, rspError 
 
 	attr, err := tools.MapToJson(r.Attributes)
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("将map转成json失败: %s", err.Error()))
+		return nil, tools.NewOperationI18nError("field_relation.map_to_json_failed", i18n.Args{"error": err.Error()})
 	}
 
 	frObj := model.FieldRelation{
@@ -95,7 +94,7 @@ func (l FieldRelationLogic) Update(c *gin.Context, req any) (data any, rspError 
 
 	err = isql.FieldRelation.Update(&frObj)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("更新动态字段关系失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("field_relation.update_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -111,13 +110,13 @@ func (l FieldRelationLogic) Delete(c *gin.Context, req any) (data any, rspError 
 	for _, id := range r.FieldRelationIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.FieldRelation.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("动态字段关系不存在"))
+			return nil, tools.NewMySqlI18nError("field_relation.not_found", nil)
 		}
 	}
 	// 删除
 	err := isql.FieldRelation.Delete(r.FieldRelationIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除动态字段关系失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("field_relation.delete_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }

--- a/logic/group_logic.go
+++ b/logic/group_logic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -30,7 +31,7 @@ func (l GroupLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 获取当前用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户信息失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	group := model.Group{
@@ -50,7 +51,7 @@ func (l GroupLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 		parentGroup := new(model.Group)
 		err := isql.Group.Find(tools.H{"id": r.ParentId}, parentGroup)
 		if err != nil {
-			return nil, tools.NewMySqlError(fmt.Errorf("获取父级组信息失败"))
+			return nil, tools.NewMySqlI18nError("group.parent_info_failed", nil)
 		}
 		group.SourceDeptId = "platform_0"
 		group.SourceDeptParentId = fmt.Sprintf("%s_%d", parentGroup.Source, r.ParentId)
@@ -59,19 +60,19 @@ func (l GroupLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 
 	// 根据 group_dn 判断分组是否已存在
 	if isql.Group.Exist(tools.H{"group_dn": group.GroupDN}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("该分组对应DN已存在"))
+		return nil, tools.NewValidatorI18nError("group.dn_exists", nil)
 	}
 
 	// 先在ldap中创建组
 	err = ildap.Group.Add(&group)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "向LDAP创建分组失败"+err.Error()))
+		return nil, tools.NewLdapI18nError("group.ldap_create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 然后在数据库中创建组
 	err = isql.Group.Add(&group)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("向MySQL创建分组失败"))
+		return nil, tools.NewLdapI18nError("group.mysql_create_failed", nil)
 	}
 
 	// 默认创建分组之后，需要将admin添加到分组中
@@ -83,7 +84,7 @@ func (l GroupLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 
 	err = isql.Group.AddUserToGroup(&group, []model.User{*adminInfo})
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("添加用户到分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.add_user_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -100,16 +101,17 @@ func (l GroupLogic) List(c *gin.Context, req any) (data any, rspError any) {
 	// 获取数据列表
 	groups, err := isql.Group.List(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]model.Group, 0)
 	for _, group := range groups {
+		localizeGroup(c, group)
 		rets = append(rets, *group)
 	}
 	count, err := isql.Group.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组总数失败"))
+		return nil, tools.NewMySqlI18nError("group.count_failed", nil)
 	}
 
 	return response.GroupListRsp{
@@ -129,10 +131,11 @@ func (l GroupLogic) GetTree(c *gin.Context, req any) (data any, rspError any) {
 	var groups []*model.Group
 	groups, err := isql.Group.ListTree(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	tree := isql.GenGroupTree(0, groups)
+	localizeGroups(c, tree)
 
 	return tree, nil
 }
@@ -147,13 +150,13 @@ func (l GroupLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	filter := tools.H{"id": int(r.ID)}
 	if !isql.Group.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("分组不存在"))
+		return nil, tools.NewMySqlI18nError("group.not_found", nil)
 	}
 
 	// 获取当前登陆用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	oldGroup := new(model.Group)
@@ -177,11 +180,11 @@ func (l GroupLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	err = ildap.Group.Update(oldGroup, &newGroup)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "向LDAP更新分组失败："+err.Error()))
+		return nil, tools.NewLdapI18nError("group.ldap_update_failed", i18n.Args{"error": err.Error()})
 	}
 	err = isql.Group.Update(&newGroup)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("向MySQL更新分组失败"))
+		return nil, tools.NewLdapI18nError("group.mysql_update_failed", nil)
 	}
 	return nil, nil
 }
@@ -197,33 +200,33 @@ func (l GroupLogic) Delete(c *gin.Context, req any) (data any, rspError any) {
 	for _, id := range r.GroupIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.Group.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("有分组不存在"))
+			return nil, tools.NewMySqlI18nError("group.some_not_found", nil)
 		}
 	}
 
 	groups, err := isql.Group.GetGroupByIds(r.GroupIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	for _, group := range groups {
 		// 判断存在子分组，不允许删除
 		filter := tools.H{"parent_id": int(group.ID)}
 		if isql.Group.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("存在子分组，请先删除子分组，再执行该分组的删除操作！"))
+			return nil, tools.NewMySqlI18nError("group.has_children", nil)
 		}
 
 		// 删除的时候先从ldap进行删除
 		err = ildap.Group.Delete(group.GroupDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "向LDAP删除分组失败："+err.Error()))
+			return nil, tools.NewLdapI18nError("group.ldap_delete_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
 	// 从MySQL中删除
 	err = isql.Group.Delete(groups)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除接口失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.delete_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -240,35 +243,35 @@ func (l GroupLogic) AddUser(c *gin.Context, req any) (data any, rspError any) {
 	filter := tools.H{"id": r.GroupID}
 
 	if !isql.Group.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("分组不存在"))
+		return nil, tools.NewMySqlI18nError("group.not_found", nil)
 	}
 
 	users, err := isql.User.GetUserByIds(r.UserIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取用户列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.user_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	group := new(model.Group)
 	err = isql.Group.Find(filter, group)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.get_failed", i18n.Args{"error": err.Error()})
 	}
 
 	if group.GroupDN[:3] == "ou=" {
-		return nil, tools.NewMySqlError(fmt.Errorf("ou类型的分组不能添加用户"))
+		return nil, tools.NewMySqlI18nError("group.ou_cannot_add_user", nil)
 	}
 
 	// 先添加到MySQL
 	err = isql.Group.AddUserToGroup(group, users)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("添加用户到分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.add_user_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 再往ldap添加
 	for _, user := range users {
 		err = ildap.Group.AddUserToGroup(group.GroupDN, user.UserDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "向LDAP添加用户到分组失败"+err.Error()))
+			return nil, tools.NewLdapI18nError("group.ldap_add_user_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
@@ -284,7 +287,7 @@ func (l GroupLogic) AddUser(c *gin.Context, req any) (data any, rspError any) {
 		newData.Departments = oldData.Departments + "," + group.GroupName
 		err = l.updataUser(newData)
 		if err != nil {
-			return nil, tools.NewOperationError(fmt.Errorf("%s", "处理用户的部门数据失败:"+err.Error()))
+			return nil, tools.NewOperationI18nError("group.user_department_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
@@ -294,7 +297,7 @@ func (l GroupLogic) AddUser(c *gin.Context, req any) (data any, rspError any) {
 func (l GroupLogic) updataUser(newUser *model.User) error {
 	err := isql.User.Update(newUser)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("%s", "在MySQL更新用户失败："+err.Error()))
+		return tools.NewMySqlI18nError("group.mysql_user_update_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil
 }
@@ -310,36 +313,36 @@ func (l GroupLogic) RemoveUser(c *gin.Context, req any) (data any, rspError any)
 	filter := tools.H{"id": r.GroupID}
 
 	if !isql.Group.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("分组不存在"))
+		return nil, tools.NewMySqlI18nError("group.not_found", nil)
 	}
 
 	users, err := isql.User.GetUserByIds(r.UserIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取用户列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.user_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	group := new(model.Group)
 	err = isql.Group.Find(filter, group)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.get_failed", i18n.Args{"error": err.Error()})
 	}
 
 	if group.GroupDN[:3] == "ou=" {
-		return nil, tools.NewMySqlError(fmt.Errorf("ou类型的分组内没有用户"))
+		return nil, tools.NewMySqlI18nError("group.ou_has_no_user", nil)
 	}
 
 	// 先操作ldap
 	for _, user := range users {
 		err := ildap.Group.RemoveUserFromGroup(group.GroupDN, user.UserDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "将用户从ldap移除失败"+err.Error()))
+			return nil, tools.NewLdapI18nError("group.ldap_remove_user_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
 	// 再操作MySQL
 	err = isql.Group.RemoveUserFromGroup(group, users)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("将用户从MySQL移除失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.mysql_remove_user_failed", i18n.Args{"error": err.Error()})
 	}
 
 	for _, user := range users {
@@ -369,7 +372,7 @@ func (l GroupLogic) RemoveUser(c *gin.Context, req any) (data any, rspError any)
 		newData.DepartmentId = strings.Join(newDeptIds, ",")
 		err = l.updataUser(newData)
 		if err != nil {
-			return nil, tools.NewOperationError(fmt.Errorf("%s", "处理用户的部门数据失败:"+err.Error()))
+			return nil, tools.NewOperationI18nError("group.user_department_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
@@ -387,13 +390,13 @@ func (l GroupLogic) UserInGroup(c *gin.Context, req any) (data any, rspError any
 	filter := tools.H{"id": r.GroupID}
 
 	if !isql.Group.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("分组不存在"))
+		return nil, tools.NewMySqlI18nError("group.not_found", nil)
 	}
 
 	group := new(model.Group)
 	err := isql.Group.Find(filter, group)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.get_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]response.Guser, 0)
@@ -432,19 +435,19 @@ func (l GroupLogic) UserNoInGroup(c *gin.Context, req any) (data any, rspError a
 	filter := tools.H{"id": r.GroupID}
 
 	if !isql.Group.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("分组不存在"))
+		return nil, tools.NewMySqlI18nError("group.not_found", nil)
 	}
 
 	group := new(model.Group)
 	err := isql.Group.Find(filter, group)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取分组失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("group.get_failed", i18n.Args{"error": err.Error()})
 	}
 
 	var userList []*model.User
 	userList, err = isql.User.ListAll()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]response.Guser, 0)

--- a/logic/menu_logic.go
+++ b/logic/menu_logic.go
@@ -1,10 +1,9 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -22,14 +21,14 @@ func (l MenuLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 
 	if isql.Menu.Exist(tools.H{"name": r.Name}) {
-		return nil, tools.NewMySqlError(fmt.Errorf("菜单名称已存在"))
+		return nil, tools.NewMySqlI18nError("menu.name_exists", nil)
 
 	}
 
 	// 获取当前用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户信息失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	menu := model.Menu{
@@ -52,39 +51,11 @@ func (l MenuLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 
 	err = isql.Menu.Add(&menu)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("创建记录失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("menu.create_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
 }
-
-// // List 数据列表
-// func (l MenuLogic) List(c *gin.Context, req any) (data any, rspError any) {
-// 	_, ok := req.(*request.MenuListReq)
-// 	if !ok {
-// 		return nil, ReqAssertErr
-// 	}
-// 	_ = c
-
-// 	menus, err := isql.Menu.List()
-// 	if err != nil {
-// 		return nil, tools.NewMySqlError(fmt.Errorf("获取资源列表失败: %s", err.Error()))
-// 	}
-
-// 	rets := make([]model.Menu, 0)
-// 	for _, menu := range menus {
-// 		rets = append(rets, *menu)
-// 	}
-// 	count, err := isql.Menu.Count()
-// 	if err != nil {
-// 		return nil, tools.NewMySqlError(fmt.Errorf("获取资源总数失败"))
-// 	}
-
-// 	return response.MenuListRsp{
-// 		Total: count,
-// 		Menus: rets,
-// 	}, nil
-// }
 
 // Update 更新数据
 func (l MenuLogic) Update(c *gin.Context, req any) (data any, rspError any) {
@@ -96,19 +67,19 @@ func (l MenuLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	filter := tools.H{"id": int(r.ID)}
 	if !isql.Menu.Exist(filter) {
-		return nil, tools.NewMySqlError(fmt.Errorf("该ID对应的记录不存在"))
+		return nil, tools.NewMySqlI18nError("menu.record_not_found", nil)
 	}
 
 	// 获取当前登陆用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	oldData := new(model.Menu)
 	err = isql.Menu.Find(filter, oldData)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取记录失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("menu.record_get_failed", i18n.Args{"error": err.Error()})
 	}
 
 	menu := model.Menu{
@@ -132,7 +103,7 @@ func (l MenuLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	err = isql.Menu.Update(&menu)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("更新记录失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("menu.update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -149,14 +120,14 @@ func (l MenuLogic) Delete(c *gin.Context, req any) (data any, rspError any) {
 	for _, id := range r.MenuIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.Menu.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("该ID对应的记录不存在"))
+			return nil, tools.NewMySqlI18nError("menu.record_not_found", nil)
 		}
 	}
 
 	// 删除接口
 	err := isql.Menu.Delete(r.MenuIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除接口失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("menu.delete_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -170,10 +141,11 @@ func (l MenuLogic) GetTree(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 	menus, err := isql.Menu.List()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	tree := isql.GenMenuTree(0, menus)
+	localizeMenus(c, tree)
 
 	return tree, nil
 }
@@ -188,12 +160,12 @@ func (l MenuLogic) GetAccessTree(c *gin.Context, req any) (data any, rspError an
 	// 校验
 	filter := tools.H{"id": r.ID}
 	if !isql.User.Exist(filter) {
-		return nil, tools.NewValidatorError(fmt.Errorf("该用户不存在"))
+		return nil, tools.NewValidatorI18nError("legacy.user.not_found", nil)
 	}
 	user := new(model.User)
 	err := isql.User.Find(filter, user)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL查询用户失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_query_failed", i18n.Args{"error": err.Error()})
 	}
 	var roleIds []uint
 	for _, role := range user.Roles {
@@ -201,10 +173,11 @@ func (l MenuLogic) GetAccessTree(c *gin.Context, req any) (data any, rspError an
 	}
 	menus, err := isql.Menu.ListUserMenus(roleIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	tree := isql.GenMenuTree(0, menus)
+	localizeMenus(c, tree)
 
 	return tree, nil
 }

--- a/logic/openldap_logic.go
+++ b/logic/openldap_logic.go
@@ -1,13 +1,13 @@
 package logic
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/openldap"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 	"github.com/gin-gonic/gin"
@@ -23,12 +23,12 @@ func (d *OpenLdapLogic) SyncOpenLdapDepts(c *gin.Context, req any) (data any, rs
 	if err != nil {
 		errMsg := fmt.Sprintf("获取OpenLDAP部门列表失败：%s", err.Error())
 		common.Log.Errorf("SyncOpenLdapDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_list_failed", i18n.Args{"provider": "OpenLDAP", "error": err.Error()})
 	}
 	if len(depts) == 0 {
 		errMsg := "获取到的部门数量为0"
 		common.Log.Errorf("SyncOpenLdapDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_depts", nil)
 	}
 	groups := make([]*model.Group, 0)
 	for _, dept := range depts {
@@ -62,14 +62,14 @@ func (d OpenLdapLogic) addDepts(depts []*model.Group) error {
 		if err != nil {
 			errMsg := fmt.Sprintf("DsyncOpenLdapDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
 			common.Log.Errorf("%s", errMsg)
-			return tools.NewOperationError(errors.New(errMsg))
+			return tools.NewOperationI18nError("sync.dept_add_failed", i18n.Args{"dept": dept.GroupName, "error": err.Error()})
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
 				errMsg := fmt.Sprintf("DsyncOpenLdapDepts添加子部门失败: %s", err.Error())
 				common.Log.Errorf("%s", errMsg)
-				return tools.NewOperationError(errors.New(errMsg))
+				return tools.NewOperationI18nError("sync.child_dept_add_failed", i18n.Args{"error": err.Error()})
 			}
 		}
 	}
@@ -111,7 +111,7 @@ func (d OpenLdapLogic) getParentGroupID(group *model.Group) (id uint, err error)
 	parentGroup := new(model.Group)
 	err = isql.Group.Find(tools.H{"source_dept_id": group.SourceDeptParentId}, parentGroup)
 	if err != nil {
-		return id, tools.NewMySqlError(fmt.Errorf("查询父级部门失败：%s,%s", err.Error(), group.GroupName))
+		return id, tools.NewMySqlI18nError("sync.parent_dept_query_failed", i18n.Args{"error": fmt.Sprintf("%s,%s", err.Error(), group.GroupName)})
 	}
 	return parentGroup.ID, nil
 }
@@ -123,12 +123,12 @@ func (d OpenLdapLogic) SyncOpenLdapUsers(c *gin.Context, req any) (data any, rsp
 	if err != nil {
 		errMsg := fmt.Sprintf("获取OpenLDAP用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncOpenLdapUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_list_failed", i18n.Args{"provider": "OpenLDAP", "error": err.Error()})
 	}
 	if len(staffs) == 0 {
 		errMsg := "获取到的用户数量为0"
 		common.Log.Errorf("SyncOpenLdapUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_users", nil)
 	}
 	// 2.遍历用户，开始写入
 	for i, staff := range staffs {
@@ -136,14 +136,14 @@ func (d OpenLdapLogic) SyncOpenLdapUsers(c *gin.Context, req any) (data any, rsp
 		if err != nil {
 			errMsg := fmt.Sprintf("将用户[%s]的部门ids转换为内部部门id失败：%s", staff.Name, err.Error())
 			common.Log.Errorf("SyncOpenLdapUsers: %s", errMsg)
-			return nil, tools.NewMySqlError(errors.New(errMsg))
+			return nil, tools.NewMySqlI18nError("sync.user_dept_ids_convert_failed", i18n.Args{"username": staff.Name, "error": err.Error()})
 		}
 		// 根据角色id获取角色
 		roles, err := isql.Role.GetRolesByIds([]uint{2})
 		if err != nil {
 			errMsg := fmt.Sprintf("获取用户[%s]的角色信息失败：%s", staff.Name, err.Error())
 			common.Log.Errorf("SyncOpenLdapUsers: %s", errMsg)
-			return nil, tools.NewValidatorError(errors.New(errMsg))
+			return nil, tools.NewValidatorI18nError("sync.user_role_info_failed", i18n.Args{"username": staff.Name, "error": err.Error()})
 		}
 		// 入库
 		err = d.AddUsers(&model.User{
@@ -168,7 +168,7 @@ func (d OpenLdapLogic) SyncOpenLdapUsers(c *gin.Context, req any) (data any, rsp
 		if err != nil {
 			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Name, err.Error())
 			common.Log.Errorf("SyncOpenLdapUsers: %s", errMsg)
-			return nil, tools.NewOperationError(errors.New(errMsg))
+			return nil, tools.NewOperationI18nError("sync.user_write_failed", i18n.Args{"username": staff.Name, "error": err.Error()})
 		}
 		common.Log.Infof("SyncOpenLdapUsers: 成功同步用户[%s] (%d/%d)", staff.Name, i+1, len(staffs))
 	}
@@ -182,22 +182,22 @@ func (d OpenLdapLogic) AddUsers(user *model.User) error {
 	// 根据 user_dn 查询用户,不存在则创建
 	if !isql.User.Exist(tools.H{"user_dn": user.UserDN}) {
 		if user.Departments == "" {
-			user.Departments = "默认:研发中心"
+			user.Departments = "Default: R&D Center"
 		}
 		if user.GivenName == "" {
 			user.GivenName = user.Nickname
 		}
 		if user.PostalAddress == "" {
-			user.PostalAddress = "默认:地球"
+			user.PostalAddress = "Default: Earth"
 		}
 		if user.Position == "" {
-			user.Position = "默认:技术"
+			user.Position = "Default: Engineer"
 		}
 		if user.Introduction == "" {
 			user.Introduction = user.Nickname
 		}
 		if user.JobNumber == "" {
-			user.JobNumber = "未启用"
+			user.JobNumber = "N/A"
 		}
 		// 先将用户添加到MySQL
 		err := isql.User.Add(user)

--- a/logic/operation_log_logic.go
+++ b/logic/operation_log_logic.go
@@ -1,11 +1,10 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -21,11 +20,10 @@ func (l OperationLogLogic) List(c *gin.Context, req any) (data any, rspError any
 		return nil, ReqAssertErr
 	}
 	_ = c
-	fmt.Println(r)
 	// 获取数据列表
 	logs, err := isql.OperationLog.List(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("operation_log.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]model.OperationLog, 0)
@@ -34,7 +32,7 @@ func (l OperationLogLogic) List(c *gin.Context, req any) (data any, rspError any
 	}
 	count, err := isql.OperationLog.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口总数失败"))
+		return nil, tools.NewMySqlI18nError("operation_log.count_failed", nil)
 	}
 
 	return response.LogListRsp{
@@ -62,13 +60,13 @@ func (l OperationLogLogic) Delete(c *gin.Context, req any) (data any, rspError a
 	for _, id := range r.OperationLogIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.OperationLog.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("该条记录不存在"))
+			return nil, tools.NewMySqlI18nError("operation_log.not_found", nil)
 		}
 	}
 	// 删除接口
 	err := isql.OperationLog.Delete(r.OperationLogIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除该改条记录失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("operation_log.delete_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -81,7 +79,7 @@ func (l OperationLogLogic) Clean(c *gin.Context, req any) (data any, rspError an
 	_ = c
 	err := isql.OperationLog.Clean()
 	if err != nil {
-		return err, nil
+		return nil, tools.NewMySqlI18nError("operation_log.clean_failed", i18n.Args{"error": err.Error()})
 	}
-	return "操作日志清空完成", nil
+	return nil, nil
 }

--- a/logic/role_logic.go
+++ b/logic/role_logic.go
@@ -1,12 +1,11 @@
 package logic
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -25,20 +24,20 @@ func (l RoleLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 
 	if isql.Role.Exist(tools.H{"name": r.Name}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("该角色名已存在"))
+		return nil, tools.NewValidatorI18nError("role.name_exists", nil)
 	}
 
 	// 获取当前用户最高角色等级
 	minSort, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前用户最高角色等级失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_max_sort_failed", i18n.Args{"error": err.Error()})
 	}
 	if minSort != 1 {
-		return nil, tools.NewValidatorError(fmt.Errorf("当前用户没有权限更新角色"))
+		return nil, tools.NewValidatorI18nError("role.no_update_permission", nil)
 	}
 	// 用户不能创建比自己等级高或相同等级的角色
 	if minSort >= r.Sort {
-		return nil, tools.NewValidatorError(fmt.Errorf("不能创建比自己等级高或相同等级的角色"))
+		return nil, tools.NewValidatorI18nError("role.cannot_create_higher_or_equal", nil)
 	}
 
 	role := model.Role{
@@ -53,7 +52,7 @@ func (l RoleLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 创建角色
 	err = isql.Role.Add(&role)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("创建角色失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.create_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -69,16 +68,17 @@ func (l RoleLogic) List(c *gin.Context, req any) (data any, rspError any) {
 	// 获取数据列表
 	roles, err := isql.Role.List(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取菜单列表失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	count, err := isql.Role.Count()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取接口总数失败"))
+		return nil, tools.NewMySqlI18nError("role.count_failed", nil)
 	}
 
 	rets := make([]model.Role, 0)
 	for _, role := range roles {
+		localizeRole(c, role)
 		rets = append(rets, *role)
 	}
 
@@ -98,33 +98,33 @@ func (l RoleLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 
 	filter := tools.H{"id": r.ID}
 	if !isql.Role.Exist(filter) {
-		return nil, tools.NewValidatorError(fmt.Errorf("该角色名不已存在"))
+		return nil, tools.NewValidatorI18nError("role.not_found", nil)
 	}
 
 	// 当前用户角色排序最小值（最高等级角色）以及当前用户
 	minSort, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前用户最高角色等级失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_max_sort_failed", i18n.Args{"error": err.Error()})
 	}
 
 	if minSort != 1 {
-		return nil, tools.NewValidatorError(fmt.Errorf("当前用户没有权限更新角色"))
+		return nil, tools.NewValidatorI18nError("role.no_update_permission", nil)
 	}
 
 	// 不能更新比自己角色等级高或相等的角色
 	// 根据path中的角色ID获取该角色信息
 	roles, _ := isql.Role.GetRolesByIds([]uint{r.ID})
 	if len(roles) == 0 {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取角色信息失败: 未找到对应角色"))
+		return nil, tools.NewMySqlI18nError("role.info_not_found", nil)
 	}
 
 	if minSort >= roles[0].Sort {
-		return nil, tools.NewValidatorError(fmt.Errorf("不能更新比自己角色等级高或相等的角色"))
+		return nil, tools.NewValidatorI18nError("role.cannot_update_higher_or_equal", nil)
 	}
 
 	// 不能把角色等级更新得比当前用户的等级高
 	if minSort >= r.Sort {
-		return nil, tools.NewValidatorError(fmt.Errorf("不能把角色等级更新得比当前用户的等级高或相同"))
+		return nil, tools.NewValidatorI18nError("role.cannot_set_higher_or_equal", nil)
 	}
 	oldData := new(model.Role)
 	err = isql.Role.Find(filter, oldData)
@@ -144,7 +144,7 @@ func (l RoleLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 	// 更新角色
 	err = isql.Role.Update(&role)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("更新角色失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 如果更新成功，且更新了角色的keyword, 则更新casbin中policy
@@ -173,15 +173,15 @@ func (l RoleLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 		// 这里需要先新增再删除（先删除再增加会出错）
 		isAdded, _ := common.CasbinEnforcer.AddPolicies(rolePolicies)
 		if !isAdded {
-			return nil, tools.NewOperationError(fmt.Errorf("更新角色成功，但角色关键字关联的权限接口更新失败"))
+			return nil, tools.NewOperationI18nError("role.keyword_policy_update_failed", nil)
 		}
 		isRemoved, _ := common.CasbinEnforcer.RemovePolicies(rolePoliciesCopy)
 		if !isRemoved {
-			return nil, tools.NewOperationError(fmt.Errorf("更新角色成功，但角色关键字关联的权限接口更新失败"))
+			return nil, tools.NewOperationI18nError("role.keyword_policy_update_failed", nil)
 		}
 		err := common.CasbinEnforcer.LoadPolicy()
 		if err != nil {
-			return nil, tools.NewOperationError(fmt.Errorf("更新角色成功，但角色关键字关联角色的权限接口策略加载失败"))
+			return nil, tools.NewOperationI18nError("role.keyword_policy_load_failed", nil)
 		}
 
 	}
@@ -206,26 +206,26 @@ func (l RoleLogic) Delete(c *gin.Context, req any) (data any, rspError any) {
 	// 获取当前登陆用户最高等级角色
 	minSort, _, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前用户最高角色等级失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_max_sort_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 获取角色信息
 	roles, _ := isql.Role.GetRolesByIds(r.RoleIds)
 	if len(roles) == 0 {
-		return nil, tools.NewMySqlError(fmt.Errorf("未能获取到角色信息"))
+		return nil, tools.NewMySqlI18nError("role.no_role_info", nil)
 	}
 
 	// 不能删除比自己角色等级高或相等的角色
 	for _, role := range roles {
 		if minSort >= role.Sort {
-			return nil, tools.NewValidatorError(fmt.Errorf("不能删除比自己角色等级高或相等的角色"))
+			return nil, tools.NewValidatorI18nError("role.cannot_delete_higher_or_equal", nil)
 		}
 	}
 
 	// 删除角色
 	err = isql.Role.Delete(r.RoleIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("删除角色失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.delete_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 删除角色成功直接清理缓存，让活跃的用户自己重新缓存最新用户信息
@@ -243,8 +243,9 @@ func (l RoleLogic) GetMenuList(c *gin.Context, req any) (data any, rspError any)
 
 	menus, err := isql.Role.GetRoleMenusById(r.RoleID)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取角色的权限菜单失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("role.menu_list_failed", i18n.Args{"error": err.Error()})
 	}
+	localizeMenus(c, menus)
 	return menus, nil
 }
 
@@ -259,14 +260,15 @@ func (l RoleLogic) GetApiList(c *gin.Context, req any) (data any, rspError any) 
 	role := new(model.Role)
 	err := isql.Role.Find(tools.H{"id": r.RoleID}, role)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("role.resource_failed", i18n.Args{"error": err.Error()})
 	}
+	localizeRole(c, role)
 
 	policies := common.CasbinEnforcer.GetFilteredPolicy(0, role.Keyword)
 
 	apis, err := isql.Api.ListAll()
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取资源列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("legacy.common.resource_list_failed", i18n.Args{"error": err.Error()})
 	}
 	accessApis := make([]*model.Api, 0)
 
@@ -280,6 +282,7 @@ func (l RoleLogic) GetApiList(c *gin.Context, req any) (data any, rspError any) 
 			}
 		}
 	}
+	localizeApis(c, accessApis)
 
 	return accessApis, nil
 }
@@ -294,26 +297,26 @@ func (l RoleLogic) UpdateMenus(c *gin.Context, req any) (data any, rspError any)
 
 	roles, _ := isql.Role.GetRolesByIds([]uint{r.RoleID})
 	if len(roles) == 0 {
-		return nil, tools.NewMySqlError(fmt.Errorf("未获取到角色信息"))
+		return nil, tools.NewMySqlI18nError("role.no_role_info", nil)
 	}
 
 	// 当前用户角色排序最小值（最高等级角色）以及当前用户
 	minSort, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前用户最高角色等级失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_max_sort_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// (非管理员)不能更新比自己角色等级高或相等角色的权限菜单
 	if minSort != 1 {
 		if minSort >= roles[0].Sort {
-			return nil, tools.NewValidatorError(fmt.Errorf("不能更新比自己角色等级高或相等角色的权限菜单"))
+			return nil, tools.NewValidatorI18nError("role.cannot_update_higher_or_equal_permissions", nil)
 		}
 	}
 
 	// 获取当前用户所拥有的权限菜单
 	ctxUserMenus, err := isql.Menu.GetUserMenusByUserId(ctxUser.ID)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取当前用户的可访问菜单列表失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_user_menu_list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 获取当前用户所拥有的权限菜单ID
@@ -329,7 +332,7 @@ func (l RoleLogic) UpdateMenus(c *gin.Context, req any) (data any, rspError any)
 	if minSort != 1 {
 		for _, id := range r.MenuIds {
 			if !funk.Contains(ctxUserMenusIds, id) {
-				return nil, tools.NewValidatorError(fmt.Errorf("无权设置ID为%d的菜单", id))
+				return nil, tools.NewValidatorI18nError("role.no_menu_permission", i18n.Args{"id": id})
 			}
 		}
 
@@ -346,7 +349,7 @@ func (l RoleLogic) UpdateMenus(c *gin.Context, req any) (data any, rspError any)
 		// 根据menuIds查询查询菜单
 		menus, err := isql.Menu.List()
 		if err != nil {
-			return nil, tools.NewValidatorError(fmt.Errorf("%s", "获取菜单列表失败: "+err.Error()))
+			return nil, tools.NewValidatorI18nError("role.menu_all_list_failed", i18n.Args{"error": err.Error()})
 		}
 		for _, menuId := range r.MenuIds {
 			for _, menu := range menus {
@@ -361,7 +364,7 @@ func (l RoleLogic) UpdateMenus(c *gin.Context, req any) (data any, rspError any)
 
 	err = isql.Role.UpdateRoleMenus(roles[0])
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "更新角色的权限菜单失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("role.update_menus_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -378,19 +381,19 @@ func (l RoleLogic) UpdateApis(c *gin.Context, req any) (data any, rspError any) 
 	// 根据path中的角色ID获取该角色信息
 	roles, _ := isql.Role.GetRolesByIds([]uint{r.RoleID})
 	if len(roles) == 0 {
-		return nil, tools.NewMySqlError(fmt.Errorf("未获取到角色信息"))
+		return nil, tools.NewMySqlI18nError("role.no_role_info", nil)
 	}
 
 	// 当前用户角色排序最小值（最高等级角色）以及当前用户
 	minSort, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前用户最高角色等级失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("role.current_max_sort_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// (非管理员)不能更新比自己角色等级高或相等角色的权限菜单
 	if minSort != 1 {
 		if minSort >= roles[0].Sort {
-			return nil, tools.NewValidatorError(fmt.Errorf("不能更新比自己角色等级高或相等角色的权限菜单"))
+			return nil, tools.NewValidatorI18nError("role.cannot_update_higher_or_equal_permissions", nil)
 		}
 	}
 
@@ -409,7 +412,7 @@ func (l RoleLogic) UpdateApis(c *gin.Context, req any) (data any, rspError any) 
 	// 根据apiID获取接口详情
 	apis, err := isql.Api.GetApisById(r.ApiIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("根据接口ID获取接口信息失败"))
+		return nil, tools.NewMySqlI18nError("role.api_info_failed", nil)
 	}
 	// 生成前端想要设置的角色policies
 	reqRolePolicies := make([][]string, 0)
@@ -423,7 +426,7 @@ func (l RoleLogic) UpdateApis(c *gin.Context, req any) (data any, rspError any) 
 	if minSort != 1 {
 		for _, reqPolicy := range reqRolePolicies {
 			if !funk.Contains(ctxRolesPolicies, reqPolicy) {
-				return nil, tools.NewValidatorError(fmt.Errorf("无权设置路径为%s,请求方式为%s的接口", reqPolicy[1], reqPolicy[2]))
+				return nil, tools.NewValidatorI18nError("role.no_api_permission", i18n.Args{"path": reqPolicy[1], "method": reqPolicy[2]})
 			}
 		}
 	}
@@ -431,7 +434,7 @@ func (l RoleLogic) UpdateApis(c *gin.Context, req any) (data any, rspError any) 
 	// 更新角色的权限接口
 	err = isql.Role.UpdateRoleApis(roles[0].Keyword, reqRolePolicies)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("更新角色的权限接口失败"))
+		return nil, tools.NewMySqlI18nError("role.update_apis_failed", nil)
 	}
 	return nil, nil
 }

--- a/logic/role_logic.go
+++ b/logic/role_logic.go
@@ -76,9 +76,9 @@ func (l RoleLogic) List(c *gin.Context, req any) (data any, rspError any) {
 		return nil, tools.NewMySqlI18nError("role.count_failed", nil)
 	}
 
+	localizeRoles(c, roles)
 	rets := make([]model.Role, 0)
 	for _, role := range roles {
-		localizeRole(c, role)
 		rets = append(rets, *role)
 	}
 

--- a/logic/user_logic.go
+++ b/logic/user_logic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/model/request"
 	"github.com/eryajf/go-ldap-admin/model/response"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -28,16 +29,16 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 
 	if isql.User.Exist(tools.H{"username": r.Username}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("用户名已存在,请勿重复添加"))
+		return nil, tools.NewValidatorI18nError("user.username_exists", nil)
 	}
 	if isql.User.Exist(tools.H{"mobile": r.Mobile}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("手机号已存在,请勿重复添加"))
+		return nil, tools.NewValidatorI18nError("user.mobile_exists", nil)
 	}
 	if isql.User.Exist(tools.H{"job_number": r.JobNumber}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("工号已存在,请勿重复添加"))
+		return nil, tools.NewValidatorI18nError("user.job_number_exists", nil)
 	}
 	if isql.User.Exist(tools.H{"mail": r.Mail}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("邮箱已存在,请勿重复添加"))
+		return nil, tools.NewValidatorI18nError("user.mail_exists", nil)
 	}
 
 	// 密码通过RSA解密
@@ -45,11 +46,11 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	if r.Password != "" {
 		decodeData, err := tools.RSADecrypt([]byte(r.Password), config.Conf.System.RSAPrivateBytes)
 		if err != nil {
-			return nil, tools.NewValidatorError(fmt.Errorf("密码解密失败"))
+			return nil, tools.NewValidatorI18nError("user.password_decrypt_failed", nil)
 		}
 		r.Password = string(decodeData)
 		if len(r.Password) < 6 {
-			return nil, tools.NewValidatorError(fmt.Errorf("密码长度至少为6位"))
+			return nil, tools.NewValidatorI18nError("user.password_min_length", i18n.Args{"min": 6})
 		}
 	} else {
 		r.Password = config.Conf.Ldap.UserInitPassword
@@ -58,7 +59,7 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 当前登陆用户角色排序最小值（最高等级角色）以及当前登陆的用户
 	currentRoleSortMin, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("获取当前登陆用户角色排序最小值失败"))
+		return nil, tools.NewValidatorI18nError("user.current_min_role_sort_failed", nil)
 	}
 
 	// 根据角色id获取角色
@@ -68,7 +69,7 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 
 	roles, err := isql.Role.GetRolesByIds(r.RoleIds)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("根据角色ID获取角色信息失败"))
+		return nil, tools.NewValidatorI18nError("user.role_info_failed", nil)
 	}
 
 	var reqRoleSorts []int
@@ -82,7 +83,7 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	if currentRoleSortMin != 1 {
 		// 当前用户的角色排序最小值 需要小于 前端传来的角色排序最小值（用户不能创建比自己等级高的或者相同等级的用户）
 		if currentRoleSortMin >= reqRoleSortMin {
-			return nil, tools.NewValidatorError(fmt.Errorf("用户不能创建比自己等级高的或者相同等级的用户"))
+			return nil, tools.NewValidatorI18nError("user.cannot_create_higher_or_equal", nil)
 		}
 	}
 	user := model.User{
@@ -113,12 +114,12 @@ func (l UserLogic) Add(c *gin.Context, req any) (data any, rspError any) {
 	// 获取用户将要添加的分组
 	groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 	}
 
-	err = CommonAddUser(&user, groups)
+	err = CommonAddUser(&user, groups, i18n.LocaleFromContext(c))
 	if err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("%s", "添加用户失败"+err.Error()))
+		return nil, tools.NewOperationI18nError("user.create_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -133,7 +134,7 @@ func (l UserLogic) List(c *gin.Context, req any) (data any, rspError any) {
 
 	users, err := isql.User.List(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取用户列表失败："+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.list_failed", i18n.Args{"error": err.Error()})
 	}
 
 	rets := make([]model.User, 0)
@@ -142,7 +143,7 @@ func (l UserLogic) List(c *gin.Context, req any) (data any, rspError any) {
 	}
 	count, err := isql.User.ListCount(r)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取用户总数失败："+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.count_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return response.UserListRsp{
@@ -160,13 +161,13 @@ func (l UserLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 	_ = c
 
 	if !isql.User.Exist(tools.H{"id": r.ID}) {
-		return nil, tools.NewMySqlError(fmt.Errorf("该记录不存在"))
+		return nil, tools.NewMySqlI18nError("legacy.common.record_not_found", nil)
 	}
 
 	// 获取当前登陆用户
 	ctxUser, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 
 	// 获取当前登陆用户角色ID集合
@@ -179,7 +180,7 @@ func (l UserLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 	var reqRoleSorts []int
 	roles, _ := isql.Role.GetRolesByIds(r.RoleIds)
 	if len(roles) == 0 {
-		return nil, tools.NewValidatorError(fmt.Errorf("根据角色ID获取角色信息失败"))
+		return nil, tools.NewValidatorI18nError("user.role_info_failed", nil)
 	}
 	for _, role := range roles {
 		reqRoleSorts = append(reqRoleSorts, int(role.Sort))
@@ -197,17 +198,17 @@ func (l UserLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 			// 不能更改自己的角色
 			reqDiff, currentDiff := funk.Difference(reqRoleSorts, currentRoleSorts)
 			if len(reqDiff.([]int)) > 0 || len(currentDiff.([]int)) > 0 {
-				return nil, tools.NewValidatorError(fmt.Errorf("不能更改自己的角色"))
+				return nil, tools.NewValidatorI18nError("user.cannot_change_self_role", nil)
 			}
 		}
 
 		// 如果是更新别人，操作者不能更新比自己角色等级高的或者相同等级的用户
 		minRoleSorts, err := isql.User.GetUserMinRoleSortsByIds([]uint{uint(r.ID)}) // 根据userIdID获取用户角色排序最小值
 		if err != nil || len(minRoleSorts) == 0 {
-			return nil, tools.NewValidatorError(fmt.Errorf("根据用户ID获取用户角色排序最小值失败"))
+			return nil, tools.NewValidatorI18nError("user.min_role_sort_by_id_failed", nil)
 		}
 		if currentRoleSortMin >= minRoleSorts[0] || currentRoleSortMin >= reqRoleSortMin {
-			return nil, tools.NewValidatorError(fmt.Errorf("用户不能更新比自己角色等级高的或者相同等级的用户"))
+			return nil, tools.NewValidatorI18nError("user.cannot_update_higher_or_equal", nil)
 		}
 	}
 
@@ -256,7 +257,7 @@ func (l UserLogic) Update(c *gin.Context, req any) (data any, rspError any) {
 	}
 
 	if err = CommonUpdateUser(oldData, &user, r.DepartmentId); err != nil {
-		return nil, tools.NewOperationError(fmt.Errorf("%s", "更新用户失败"+err.Error()))
+		return nil, tools.NewOperationI18nError("user.update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -273,51 +274,51 @@ func (l UserLogic) Delete(c *gin.Context, req any) (data any, rspError any) {
 	for _, id := range r.UserIds {
 		filter := tools.H{"id": int(id)}
 		if !isql.User.Exist(filter) {
-			return nil, tools.NewMySqlError(fmt.Errorf("有用户不存在"))
+			return nil, tools.NewMySqlI18nError("legacy.user.some_not_found", nil)
 		}
 	}
 
 	// 根据用户ID获取用户角色排序最小值
 	roleMinSortList, err := isql.User.GetUserMinRoleSortsByIds(r.UserIds)
 	if err != nil || len(roleMinSortList) == 0 {
-		return nil, tools.NewValidatorError(fmt.Errorf("根据用户ID获取用户角色排序最小值失败"))
+		return nil, tools.NewValidatorI18nError("user.min_role_sort_by_id_failed", nil)
 	}
 
 	// 获取当前登陆用户角色排序最小值（最高等级角色）以及当前用户
 	minSort, ctxUser, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("获取当前登陆用户角色排序最小值失败"))
+		return nil, tools.NewValidatorI18nError("user.current_min_role_sort_failed", nil)
 	}
 
 	// 不能删除自己
 	if funk.Contains(r.UserIds, ctxUser.ID) {
-		return nil, tools.NewValidatorError(fmt.Errorf("用户不能删除自己"))
+		return nil, tools.NewValidatorI18nError("user.cannot_delete_self", nil)
 	}
 
 	// 不能删除比自己(登陆用户)角色排序低(等级高)的用户
 	for _, sort := range roleMinSortList {
 		if int(minSort) > sort {
-			return nil, tools.NewValidatorError(fmt.Errorf("用户不能删除比自己角色等级高的用户"))
+			return nil, tools.NewValidatorI18nError("user.cannot_delete_higher", nil)
 		}
 	}
 
 	users, err := isql.User.GetUserByIds(r.UserIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取用户信息失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.info_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 先将用户从ldap中删除
 	for _, user := range users {
 		err := ildap.User.Delete(user.UserDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "在LDAP删除用户失败"+err.Error()))
+			return nil, tools.NewLdapI18nError("user.ldap_delete_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 
 	// 再将用户从MySQL中删除
 	err = isql.User.Delete(r.UserIds)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL删除用户失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_delete_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -334,39 +335,36 @@ func (l UserLogic) ChangePwd(c *gin.Context, req any) (data any, rspError any) {
 	// 密码通过RSA解密
 	decodeOldPassword, err := tools.RSADecrypt([]byte(r.OldPassword), config.Conf.System.RSAPrivateBytes)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("原密码解析失败"))
+		return nil, tools.NewValidatorI18nError("legacy.user.old_password_parse_failed", nil)
 	}
 	decodeNewPassword, err := tools.RSADecrypt([]byte(r.NewPassword), config.Conf.System.RSAPrivateBytes)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("新密码解析失败"))
+		return nil, tools.NewValidatorI18nError("legacy.user.new_password_parse_failed", nil)
 	}
 	r.OldPassword = string(decodeOldPassword)
 	r.NewPassword = string(decodeNewPassword)
 	// 获取当前用户
 	user, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取当前登陆用户失败"))
+		return nil, tools.NewMySqlI18nError("legacy.common.current_user_failed", nil)
 	}
 	// 获取用户的真实正确密码
 	// correctPasswd := user.Password
 	// 判断前端请求的密码是否等于真实密码
 	// err = tools.ComparePasswd(correctPasswd, r.OldPassword)
-	// if err != nil {
-	// 	return nil, tools.NewValidatorError(fmt.Errorf("原密码错误"))
-	// }
 	if tools.NewParPasswd(user.Password) != r.OldPassword {
-		return nil, tools.NewValidatorError(fmt.Errorf("原密码错误"))
+		return nil, tools.NewValidatorI18nError("legacy.user.old_password_incorrect", nil)
 	}
 	// ldap更新密码时可以直接指定用户DN和新密码即可更改成功
 	err = ildap.User.ChangePwd(user.UserDN, "", r.NewPassword)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("%s", "在LDAP更新密码失败"+err.Error()))
+		return nil, tools.NewLdapI18nError("user.ldap_password_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 更新密码
 	err = isql.User.ChangePwd(user.Username, tools.NewGenPasswd(r.NewPassword))
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL更新密码失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_password_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	return nil, nil
@@ -382,14 +380,14 @@ func (l UserLogic) ResetPassword(c *gin.Context, req any) (data any, rspError an
 
 	// 检查用户是否存在
 	if !isql.User.Exist(tools.H{"username": r.Username}) {
-		return nil, tools.NewValidatorError(fmt.Errorf("用户不存在"))
+		return nil, tools.NewValidatorI18nError("user.not_found", nil)
 	}
 
 	// 获取用户信息
 	user := new(model.User)
 	err := isql.User.Find(tools.H{"username": r.Username}, user)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("获取用户信息失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("user.info_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 生成随机密码
@@ -398,17 +396,17 @@ func (l UserLogic) ResetPassword(c *gin.Context, req any) (data any, rspError an
 	// 在LDAP中更新密码
 	err = ildap.User.ChangePwd(user.UserDN, "", newPassword)
 	if err != nil {
-		return nil, tools.NewLdapError(fmt.Errorf("在LDAP更新密码失败: %s", err.Error()))
+		return nil, tools.NewLdapI18nError("user.ldap_password_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 在MySQL中更新密码
 	err = isql.User.ChangePwd(user.Username, tools.NewGenPasswd(newPassword))
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("在MySQL更新密码失败: %s", err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_password_update_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 发送密码重置通知邮件
-	if err := tools.SendPasswordResetNotification(user.Username, user.Nickname, user.Mail, newPassword); err != nil {
+	if err := tools.SendPasswordResetNotificationI18n(user.Username, user.Nickname, user.Mail, newPassword, i18n.LocaleFromContext(c)); err != nil {
 		common.Log.Warnf("发送密码重置通知邮件失败，用户: %s, 邮箱: %s, 错误: %v", user.Username, user.Mail, err)
 	}
 
@@ -425,46 +423,46 @@ func (l UserLogic) ChangeUserStatus(c *gin.Context, req any) (data any, rspError
 	// 校验工作
 	filter := tools.H{"id": r.ID}
 	if !isql.User.Exist(filter) {
-		return nil, tools.NewValidatorError(fmt.Errorf("该用户不存在"))
+		return nil, tools.NewValidatorI18nError("legacy.user.not_found", nil)
 	}
 	user := new(model.User)
 	err := isql.User.Find(filter, user)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL查询用户失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_query_failed", i18n.Args{"error": err.Error()})
 	}
 
 	if r.Status == 1 && r.Status == user.Status {
-		return nil, tools.NewValidatorError(fmt.Errorf("用户已经是在职状态"))
+		return nil, tools.NewValidatorI18nError("legacy.user.already_active", nil)
 	}
 	if r.Status == 2 && r.Status == user.Status {
-		return nil, tools.NewValidatorError(fmt.Errorf("用户已经是离职状态"))
+		return nil, tools.NewValidatorI18nError("legacy.user.already_inactive", nil)
 	}
 
 	// 获取当前登录用户，只有管理员才能够将用户状态改变
 	// 获取当前登陆用户角色排序最小值（最高等级角色）以及当前用户
 	minSort, _, err := isql.User.GetCurrentUserMinRoleSort(c)
 	if err != nil {
-		return nil, tools.NewValidatorError(fmt.Errorf("获取当前登陆用户角色排序最小值失败"))
+		return nil, tools.NewValidatorI18nError("user.current_min_role_sort_failed", nil)
 	}
 
 	if int(minSort) != 1 {
-		return nil, tools.NewValidatorError(fmt.Errorf("只有管理员才能更改用户状态"))
+		return nil, tools.NewValidatorI18nError("legacy.user.only_admin_change_status", nil)
 	}
 
 	if r.Status == 2 {
 		err = ildap.User.Delete(user.UserDN)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "在LDAP删除用户失败"+err.Error()))
+			return nil, tools.NewLdapI18nError("user.ldap_delete_failed", i18n.Args{"error": err.Error()})
 		}
 	} else {
 		err = ildap.User.Add(user)
 		if err != nil {
-			return nil, tools.NewLdapError(fmt.Errorf("%s", "在LDAP添加用户失败"+err.Error()))
+			return nil, tools.NewLdapI18nError("user.ldap_add_failed", i18n.Args{"error": err.Error()})
 		}
 	}
 	err = isql.User.ChangeStatus(int(r.ID), int(r.Status))
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "在MySQL更新用户状态失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.mysql_status_update_failed", i18n.Args{"error": err.Error()})
 	}
 	return nil, nil
 }
@@ -481,7 +479,7 @@ func (l UserLogic) GetUserInfo(c *gin.Context, req any) (data any, rspError any)
 
 	user, err := isql.User.GetCurrentLoginUser(c)
 	if err != nil {
-		return nil, tools.NewMySqlError(fmt.Errorf("%s", "获取当前用户信息失败: "+err.Error()))
+		return nil, tools.NewMySqlI18nError("user.current_info_failed", i18n.Args{"error": err.Error()})
 	}
 	return user, nil
 }

--- a/logic/wecom_logic.go
+++ b/logic/wecom_logic.go
@@ -1,7 +1,6 @@
 package logic
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/client/wechat"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/ildap"
 	"github.com/eryajf/go-ldap-admin/service/isql"
@@ -25,18 +25,18 @@ func (d *WeComLogic) SyncWeComDepts(c *gin.Context, req any) (data any, rspError
 	if err != nil {
 		errMsg := fmt.Sprintf("获取企业微信部门列表失败：%s", err.Error())
 		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_list_failed", i18n.Args{"provider": "WeCom", "error": err.Error()})
 	}
 	depts, err := ConvertDeptData(config.Conf.WeCom.Flag, deptSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换企业微信部门数据失败：%s", err.Error())
 		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.dept_convert_failed", i18n.Args{"provider": "WeCom", "error": err.Error()})
 	}
 	if len(depts) == 0 {
 		errMsg := "获取到的部门数量为0"
 		common.Log.Errorf("SyncWeComDepts: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_depts", nil)
 	}
 
 	// 2.将远程数据转换成树
@@ -61,14 +61,14 @@ func (d WeComLogic) addDepts(depts []*model.Group) error {
 		if err != nil {
 			errMsg := fmt.Sprintf("DsyncWeComDepts添加部门[%s]失败: %s", dept.GroupName, err.Error())
 			common.Log.Errorf("%s", errMsg)
-			return tools.NewOperationError(errors.New(errMsg))
+			return tools.NewOperationI18nError("sync.dept_add_failed", i18n.Args{"dept": dept.GroupName, "error": err.Error()})
 		}
 		if len(dept.Children) != 0 {
 			err = d.addDepts(dept.Children)
 			if err != nil {
 				errMsg := fmt.Sprintf("DsyncWeComDepts添加子部门失败: %s", err.Error())
 				common.Log.Errorf("%s", errMsg)
-				return tools.NewOperationError(errors.New(errMsg))
+				return tools.NewOperationI18nError("sync.child_dept_add_failed", i18n.Args{"error": err.Error()})
 			}
 		}
 	}
@@ -81,7 +81,7 @@ func (d WeComLogic) AddDepts(group *model.Group) error {
 	parentGroup := new(model.Group)
 	err := isql.Group.Find(tools.H{"source_dept_id": group.SourceDeptParentId}, parentGroup)
 	if err != nil {
-		return tools.NewMySqlError(fmt.Errorf("查询父级部门失败：%s", err.Error()))
+		return tools.NewMySqlI18nError("sync.parent_dept_query_failed", i18n.Args{"error": err.Error()})
 	}
 
 	// 此时的 group 已经附带了Build后动态关联好的字段，接下来将一些确定性的其他字段值添加上，就可以创建这个分组了
@@ -94,7 +94,7 @@ func (d WeComLogic) AddDepts(group *model.Group) error {
 	if !isql.Group.Exist(tools.H{"group_dn": group.GroupDN}) {
 		err = CommonAddGroup(group)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加部门: %s, 失败: %s", group.GroupName, err.Error()))
+			return tools.NewOperationI18nError("sync.add_dept_failed", i18n.Args{"dept": group.GroupName, "error": err.Error()})
 		}
 	}
 	return nil
@@ -107,18 +107,18 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req any) (data any, rspError 
 	if err != nil {
 		errMsg := fmt.Sprintf("获取企业微信用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_list_failed", i18n.Args{"provider": "WeCom", "error": err.Error()})
 	}
 	staffs, err := ConvertUserData(config.Conf.WeCom.Flag, staffSource)
 	if err != nil {
 		errMsg := fmt.Sprintf("转换企业微信用户数据失败：%s", err.Error())
 		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.user_convert_failed", i18n.Args{"provider": "WeCom", "error": err.Error()})
 	}
 	if len(staffs) == 0 {
 		errMsg := "获取到的用户数量为0"
 		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-		return nil, tools.NewOperationError(errors.New(errMsg))
+		return nil, tools.NewOperationI18nError("sync.empty_users", nil)
 	}
 	// 2.遍历用户，开始写入
 	for i, staff := range staffs {
@@ -127,7 +127,7 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req any) (data any, rspError 
 		if err != nil {
 			errMsg := fmt.Sprintf("写入用户[%s]失败：%s", staff.Username, err.Error())
 			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-			return nil, tools.NewOperationError(errors.New(errMsg))
+			return nil, tools.NewOperationI18nError("sync.user_write_failed", i18n.Args{"username": staff.Username, "error": err.Error()})
 		}
 		common.Log.Infof("SyncWeComUsers: 成功同步用户[%s] (%d/%d)", staff.Username, i+1, len(staffs))
 	}
@@ -140,7 +140,7 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req any) (data any, rspError 
 	if err != nil {
 		errMsg := fmt.Sprintf("获取MySQL用户列表失败：%s", err.Error())
 		common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-		return nil, tools.NewMySqlError(errors.New(errMsg))
+		return nil, tools.NewMySqlI18nError("sync.mysql_user_list_failed", i18n.Args{"error": err.Error()})
 	}
 	for _, user := range users {
 		if user.Source != config.Conf.WeCom.Flag {
@@ -165,21 +165,21 @@ func (d WeComLogic) SyncWeComUsers(c *gin.Context, req any) (data any, rspError 
 		if err != nil {
 			errMsg := fmt.Sprintf("在MySQL查询离职用户[%s]失败: %s", userTmp.Username, err.Error())
 			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-			return nil, tools.NewMySqlError(errors.New(errMsg))
+			return nil, tools.NewMySqlI18nError("sync.leave_user_query_failed", i18n.Args{"username": userTmp.Username, "error": err.Error()})
 		}
 		// 先从ldap删除用户
 		err = ildap.User.Delete(user.UserDN)
 		if err != nil {
 			errMsg := fmt.Sprintf("在LDAP删除离职用户[%s]失败: %s", user.Username, err.Error())
 			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-			return nil, tools.NewLdapError(errors.New(errMsg))
+			return nil, tools.NewLdapI18nError("sync.leave_user_ldap_delete_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 		}
 		// 然后更新MySQL中用户状态
 		err = isql.User.ChangeStatus(int(user.ID), 2)
 		if err != nil {
 			errMsg := fmt.Sprintf("在MySQL更新离职用户[%s]状态失败: %s", user.Username, err.Error())
 			common.Log.Errorf("SyncWeComUsers: %s", errMsg)
-			return nil, tools.NewMySqlError(errors.New(errMsg))
+			return nil, tools.NewMySqlI18nError("sync.leave_user_status_update_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 		}
 		processedCount++
 		common.Log.Infof("SyncWeComUsers: 成功处理离职用户[%s]", user.Username)
@@ -194,7 +194,7 @@ func (d WeComLogic) AddUsers(user *model.User) error {
 	// 根据角色id获取角色
 	roles, err := isql.Role.GetRolesByIds([]uint{2})
 	if err != nil {
-		return tools.NewValidatorError(fmt.Errorf("根据角色ID获取角色信息失败:%s", err.Error()))
+		return tools.NewValidatorI18nError("sync.role_info_failed", i18n.Args{"error": err.Error()})
 	}
 	user.Creator = "system"
 	user.Roles = roles
@@ -207,7 +207,7 @@ func (d WeComLogic) AddUsers(user *model.User) error {
 		// 获取用户将要添加的分组
 		groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 		if err != nil {
-			return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+			return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 		}
 		var deptTmp string
 		for _, group := range groups {
@@ -218,7 +218,7 @@ func (d WeComLogic) AddUsers(user *model.User) error {
 		// 创建用户
 		err = CommonAddUser(user, groups)
 		if err != nil {
-			return tools.NewOperationError(fmt.Errorf("添加用户: %s, 失败: %s", user.Username, err.Error()))
+			return tools.NewOperationI18nError("sync.add_user_failed", i18n.Args{"username": user.Username, "error": err.Error()})
 		}
 	} else {
 		// 此处逻辑未经实际验证，如在使用中有问题，请反馈
@@ -232,7 +232,7 @@ func (d WeComLogic) AddUsers(user *model.User) error {
 			// 获取用户将要添加的分组
 			groups, err := isql.Group.GetGroupByIds(tools.StringToSlice(user.DepartmentId, ","))
 			if err != nil {
-				return tools.NewMySqlError(fmt.Errorf("%s", "根据部门ID获取部门信息失败"+err.Error()))
+				return tools.NewMySqlI18nError("user.department_info_failed", i18n.Args{"error": err.Error()})
 			}
 			var deptTmp string
 			for _, group := range groups {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/middleware"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/routes"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 )
@@ -35,6 +36,10 @@ func main() {
 
 	// 加载配置文件到全局配置结构体
 	config.InitConfig()
+
+	if err := i18n.Init(config.Conf.I18n.DefaultLocale, config.Conf.I18n.SupportedLocales); err != nil {
+		panic(fmt.Errorf("初始化i18n失败:%s", err))
+	}
 
 	// 初始化日志
 	common.InitLogger()

--- a/middleware/AuthMiddleware.go
+++ b/middleware/AuthMiddleware.go
@@ -1,11 +1,10 @@
 package middleware
 
 import (
-	"fmt"
-
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -111,7 +110,26 @@ func authorizator(data any, c *gin.Context) bool {
 // 用户登录校验失败处理
 func unauthorized(c *gin.Context, code int, message string) {
 	common.Log.Debugf("JWT认证失败, 错误码: %d, 错误信息: %s", code, message)
-	response.Response(c, code, code, nil, fmt.Sprintf("JWT认证失败, 错误码: %d, 错误信息: %s", code, message))
+	message = localizeAuthFailure(c, message)
+	response.Response(c, code, code, nil, i18n.TC(c, "auth.jwt_failed", i18n.Args{
+		"code":    code,
+		"message": message,
+	}))
+}
+
+func localizeAuthFailure(c *gin.Context, message string) string {
+	switch message {
+	case "用户未登录":
+		return i18n.TC(c, "auth.not_logged_in", nil)
+	case "用户不存在":
+		return i18n.TC(c, "auth.user_not_found", nil)
+	case "用户被禁用":
+		return i18n.TC(c, "auth.user_disabled", nil)
+	case "密码错误":
+		return i18n.TC(c, "auth.password_incorrect", nil)
+	default:
+		return message
+	}
 }
 
 // 登录成功后的响应
@@ -121,12 +139,12 @@ func loginResponse(c *gin.Context, code int, token string, expires time.Time) {
 			"token":   token,
 			"expires": expires.Format("2006-01-02 15:04:05"),
 		},
-		"登录成功")
+		i18n.TC(c, "auth.login_success", nil))
 }
 
 // 登出后的响应
 func logoutResponse(c *gin.Context, code int) {
-	response.Success(c, nil, "退出成功")
+	response.Success(c, nil, i18n.TC(c, "auth.logout_success", nil))
 }
 
 // 刷新token后的响应
@@ -136,5 +154,5 @@ func refreshResponse(c *gin.Context, code int, token string, expires time.Time) 
 			"token":   token,
 			"expires": expires,
 		},
-		"刷新token成功")
+		i18n.TC(c, "auth.refresh_success", nil))
 }

--- a/middleware/AuthMiddleware_test.go
+++ b/middleware/AuthMiddleware_test.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+func TestLocalizeAuthFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {
+			"auth.not_logged_in":      "用户未登录",
+			"auth.user_not_found":     "用户不存在",
+			"auth.user_disabled":      "当前用户已被禁用",
+			"auth.password_incorrect": "密码错误",
+			"auth.jwt_failed":         "JWT认证失败, 错误码: {code}, 错误信息: {message}",
+		},
+		"en-US": {
+			"auth.not_logged_in":      "user is not logged in",
+			"auth.user_not_found":     "user does not exist",
+			"auth.user_disabled":      "the current user has been disabled",
+			"auth.password_incorrect": "incorrect password",
+			"auth.jwt_failed":         "JWT authentication failed, code: {code}, message: {message}",
+		},
+	})
+
+	c, _ := gin.CreateTestContext(nil)
+	i18n.SetLocale(c, "en-US")
+
+	tests := map[string]string{
+		"用户未登录": "user is not logged in",
+		"用户不存在": "user does not exist",
+		"用户被禁用": "the current user has been disabled",
+		"密码错误":  "incorrect password",
+	}
+	for raw, want := range tests {
+		if got := localizeAuthFailure(c, raw); got != want {
+			t.Fatalf("localizeAuthFailure(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/middleware/CasbinMiddleware.go
+++ b/middleware/CasbinMiddleware.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/eryajf/go-ldap-admin/public/tools"
 	"github.com/eryajf/go-ldap-admin/service/isql"
 
@@ -19,12 +20,12 @@ func CasbinMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		user, err := isql.User.GetCurrentLoginUser(c)
 		if err != nil {
-			tools.Response(c, 401, 401, nil, "用户未登录")
+			tools.Response(c, 401, 401, nil, i18n.TC(c, "auth.not_logged_in", nil))
 			c.Abort()
 			return
 		}
 		if user.Status != 1 {
-			tools.Response(c, 401, 401, nil, "当前用户已被禁用")
+			tools.Response(c, 401, 401, nil, i18n.TC(c, "auth.user_disabled", nil))
 			c.Abort()
 			return
 		}
@@ -43,7 +44,7 @@ func CasbinMiddleware() gin.HandlerFunc {
 		act := c.Request.Method
 		isPass := check(subs, obj, act)
 		if !isPass {
-			tools.Response(c, 401, 401, nil, "没有权限")
+			tools.Response(c, 401, 401, nil, i18n.TC(c, "auth.no_permission", nil))
 			c.Abort()
 			return
 		}

--- a/middleware/LocaleMiddleware.go
+++ b/middleware/LocaleMiddleware.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+func LocaleMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		locale := c.GetHeader("X-Locale")
+		if locale == "" {
+			locale = c.GetHeader("Accept-Language")
+		}
+		i18n.SetLocale(c, locale)
+		c.Next()
+	}
+}

--- a/middleware/LocaleMiddleware_test.go
+++ b/middleware/LocaleMiddleware_test.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+func TestLocaleMiddlewareUsesXLocale(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+
+	r := gin.New()
+	r.Use(LocaleMiddleware())
+	r.GET("/locale", func(c *gin.Context) {
+		c.String(http.StatusOK, i18n.LocaleFromContext(c))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/locale", nil)
+	req.Header.Set("X-Locale", "en-US")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "en-US" {
+		t.Fatalf("locale = %q", rec.Body.String())
+	}
+}
+
+func TestLocaleMiddlewareFallsBackToAcceptLanguage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+
+	r := gin.New()
+	r.Use(LocaleMiddleware())
+	r.GET("/locale", func(c *gin.Context) {
+		c.String(http.StatusOK, i18n.LocaleFromContext(c))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/locale", nil)
+	req.Header.Set("Accept-Language", "en-GB,en;q=0.8")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "en-US" {
+		t.Fatalf("locale = %q", rec.Body.String())
+	}
+}

--- a/middleware/RateLimitMiddleware.go
+++ b/middleware/RateLimitMiddleware.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/eryajf/go-ldap-admin/model/response"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 
 	"github.com/gin-gonic/gin"
 	"github.com/juju/ratelimit"
@@ -13,7 +14,7 @@ func RateLimitMiddleware(fillInterval time.Duration, capacity int64) gin.Handler
 	bucket := ratelimit.NewBucket(fillInterval, capacity)
 	return func(c *gin.Context) {
 		if bucket.TakeAvailable(1) < 1 {
-			response.Fail(c, nil, "访问限流")
+			response.Fail(c, nil, i18n.TC(c, "rate_limit.limited", nil))
 			c.Abort()
 			return
 		}

--- a/model/api.go
+++ b/model/api.go
@@ -4,9 +4,12 @@ import "gorm.io/gorm"
 
 type Api struct {
 	gorm.Model
-	Method   string `gorm:"type:varchar(20);comment:'请求方式'" json:"method"`
-	Path     string `gorm:"type:varchar(100);comment:'访问路径'" json:"path"`
-	Category string `gorm:"type:varchar(50);comment:'所属类别'" json:"category"`
-	Remark   string `gorm:"type:varchar(100);comment:'备注'" json:"remark"`
-	Creator  string `gorm:"type:varchar(20);comment:'创建人'" json:"creator"`
+	Method          string `gorm:"type:varchar(20);comment:'请求方式'" json:"method"`
+	Path            string `gorm:"type:varchar(100);comment:'访问路径'" json:"path"`
+	Category        string `gorm:"type:varchar(50);comment:'所属类别'" json:"category"`
+	CategoryDisplay string `gorm:"-" json:"categoryDisplay,omitempty"`
+	Remark          string `gorm:"type:varchar(100);comment:'备注'" json:"remark"`
+	RemarkDisplay   string `gorm:"-" json:"remarkDisplay,omitempty"`
+	Creator         string `gorm:"type:varchar(20);comment:'创建人'" json:"creator"`
+	CreatorDisplay  string `gorm:"-" json:"creatorDisplay,omitempty"`
 }

--- a/model/group.go
+++ b/model/group.go
@@ -7,8 +7,11 @@ import (
 type Group struct {
 	gorm.Model
 	GroupName          string   `gorm:"type:varchar(128);comment:'分组名称'" json:"groupName"`
+	GroupNameDisplay   string   `gorm:"-" json:"groupNameDisplay,omitempty"`
 	Remark             string   `gorm:"type:varchar(128);comment:'分组中文说明'" json:"remark"`
+	RemarkDisplay      string   `gorm:"-" json:"remarkDisplay,omitempty"`
 	Creator            string   `gorm:"type:varchar(20);comment:'创建人'" json:"creator"`
+	CreatorDisplay     string   `gorm:"-" json:"creatorDisplay,omitempty"`
 	GroupType          string   `gorm:"type:varchar(20);comment:'分组类型：cn、ou'" json:"groupType"`
 	Users              []*User  `gorm:"many2many:group_users" json:"users"`
 	ParentId           uint     `gorm:"default:0;comment:'父组编号(编号为0时表示根组)'" json:"parentId"`

--- a/model/menu.go
+++ b/model/menu.go
@@ -6,21 +6,24 @@ import (
 
 type Menu struct {
 	gorm.Model
-	Name       string  `gorm:"type:varchar(50);comment:'菜单名称(英文名, 可用于国际化)'" json:"name"`
-	Title      string  `gorm:"type:varchar(50);comment:'菜单标题(无法国际化时使用)'" json:"title"`
-	Icon       string  `gorm:"type:varchar(50);comment:'菜单图标'" json:"icon"`
-	Path       string  `gorm:"type:varchar(100);comment:'菜单访问路径'" json:"path"`
-	Redirect   string  `gorm:"type:varchar(100);comment:'重定向路径'" json:"redirect"`
-	Component  string  `gorm:"type:varchar(100);comment:'前端组件路径'" json:"component"`
-	Sort       uint    `gorm:"type:int(3);default:999;comment:'菜单顺序(1-999)'" json:"sort"`
-	Status     uint    `gorm:"type:tinyint(1);default:1;comment:'菜单状态(正常/禁用, 默认正常)'" json:"status"`
-	Hidden     uint    `gorm:"type:tinyint(1);default:2;comment:'菜单在侧边栏隐藏(1隐藏，2显示)'" json:"hidden"`
-	NoCache    uint    `gorm:"type:tinyint(1);default:2;comment:'菜单是否被 <keep-alive> 缓存(1不缓存，2缓存)'" json:"noCache"`
-	AlwaysShow uint    `gorm:"type:tinyint(1);default:2;comment:'忽略之前定义的规则，一直显示根路由(1忽略，2不忽略)'" json:"alwaysShow"`
-	Breadcrumb uint    `gorm:"type:tinyint(1);default:1;comment:'面包屑可见性(可见/隐藏, 默认可见)'" json:"breadcrumb"`
-	ActiveMenu string  `gorm:"type:varchar(100);comment:'在其它路由时，想在侧边栏高亮的路由'" json:"activeMenu"`
-	ParentId   uint    `gorm:"default:0;comment:'父菜单编号(编号为0时表示根菜单)'" json:"parentId"`
-	Creator    string  `gorm:"type:varchar(20);comment:'创建人'" json:"creator"`
-	Children   []*Menu `gorm:"-" json:"children"`                  // 子菜单集合
-	Roles      []*Role `gorm:"many2many:role_menus;" json:"roles"` // 角色菜单多对多关系
+	Name           string  `gorm:"type:varchar(50);comment:'菜单名称(英文名, 可用于国际化)'" json:"name"`
+	NameDisplay    string  `gorm:"-" json:"nameDisplay,omitempty"`
+	Title          string  `gorm:"type:varchar(50);comment:'菜单标题(无法国际化时使用)'" json:"title"`
+	TitleDisplay   string  `gorm:"-" json:"titleDisplay,omitempty"`
+	Icon           string  `gorm:"type:varchar(50);comment:'菜单图标'" json:"icon"`
+	Path           string  `gorm:"type:varchar(100);comment:'菜单访问路径'" json:"path"`
+	Redirect       string  `gorm:"type:varchar(100);comment:'重定向路径'" json:"redirect"`
+	Component      string  `gorm:"type:varchar(100);comment:'前端组件路径'" json:"component"`
+	Sort           uint    `gorm:"type:int(3);default:999;comment:'菜单顺序(1-999)'" json:"sort"`
+	Status         uint    `gorm:"type:tinyint(1);default:1;comment:'菜单状态(正常/禁用, 默认正常)'" json:"status"`
+	Hidden         uint    `gorm:"type:tinyint(1);default:2;comment:'菜单在侧边栏隐藏(1隐藏，2显示)'" json:"hidden"`
+	NoCache        uint    `gorm:"type:tinyint(1);default:2;comment:'菜单是否被 <keep-alive> 缓存(1不缓存，2缓存)'" json:"noCache"`
+	AlwaysShow     uint    `gorm:"type:tinyint(1);default:2;comment:'忽略之前定义的规则，一直显示根路由(1忽略，2不忽略)'" json:"alwaysShow"`
+	Breadcrumb     uint    `gorm:"type:tinyint(1);default:1;comment:'面包屑可见性(可见/隐藏, 默认可见)'" json:"breadcrumb"`
+	ActiveMenu     string  `gorm:"type:varchar(100);comment:'在其它路由时，想在侧边栏高亮的路由'" json:"activeMenu"`
+	ParentId       uint    `gorm:"default:0;comment:'父菜单编号(编号为0时表示根菜单)'" json:"parentId"`
+	Creator        string  `gorm:"type:varchar(20);comment:'创建人'" json:"creator"`
+	CreatorDisplay string  `gorm:"-" json:"creatorDisplay,omitempty"`
+	Children       []*Menu `gorm:"-" json:"children"`                  // 子菜单集合
+	Roles          []*Role `gorm:"many2many:role_menus;" json:"roles"` // 角色菜单多对多关系
 }

--- a/model/response/api_rsp.go
+++ b/model/response/api_rsp.go
@@ -3,10 +3,12 @@ package response
 import "github.com/eryajf/go-ldap-admin/model"
 
 type ApiTreeRsp struct {
-	ID       int          `json:"ID"`
-	Remark   string       `json:"remark"`
-	Category string       `json:"category"`
-	Children []*model.Api `json:"children"`
+	ID              int          `json:"ID"`
+	Remark          string       `json:"remark"`
+	RemarkDisplay   string       `json:"remarkDisplay,omitempty"`
+	Category        string       `json:"category"`
+	CategoryDisplay string       `json:"categoryDisplay,omitempty"`
+	Children        []*model.Api `json:"children"`
 }
 
 type ApiListRsp struct {

--- a/model/role.go
+++ b/model/role.go
@@ -4,12 +4,15 @@ import "gorm.io/gorm"
 
 type Role struct {
 	gorm.Model
-	Name    string  `gorm:"type:varchar(20);not null;unique" json:"name"`
-	Keyword string  `gorm:"type:varchar(20);not null;unique" json:"keyword"`
-	Remark  string  `gorm:"type:varchar(100);comment:'备注'" json:"remark"`
-	Status  uint    `gorm:"type:tinyint(1);default:1;comment:'1正常, 2禁用'" json:"status"`
-	Sort    uint    `gorm:"type:int(3);default:999;comment:'角色排序(排序越大权限越低, 不能查看比自己序号小的角色, 不能编辑同序号用户权限, 排序为1表示超级管理员)'" json:"sort"`
-	Creator string  `gorm:"type:varchar(20);" json:"creator"`
-	Users   []*User `gorm:"many2many:user_roles" json:"users"`
-	Menus   []*Menu `gorm:"many2many:role_menus;" json:"menus"` // 角色菜单多对多关系
+	Name           string  `gorm:"type:varchar(20);not null;unique" json:"name"`
+	NameDisplay    string  `gorm:"-" json:"nameDisplay,omitempty"`
+	Keyword        string  `gorm:"type:varchar(20);not null;unique" json:"keyword"`
+	Remark         string  `gorm:"type:varchar(100);comment:'备注'" json:"remark"`
+	RemarkDisplay  string  `gorm:"-" json:"remarkDisplay,omitempty"`
+	Status         uint    `gorm:"type:tinyint(1);default:1;comment:'1正常, 2禁用'" json:"status"`
+	Sort           uint    `gorm:"type:int(3);default:999;comment:'角色排序(排序越大权限越低, 不能查看比自己序号小的角色, 不能编辑同序号用户权限, 排序为1表示超级管理员)'" json:"sort"`
+	Creator        string  `gorm:"type:varchar(20);" json:"creator"`
+	CreatorDisplay string  `gorm:"-" json:"creatorDisplay,omitempty"`
+	Users          []*User `gorm:"many2many:user_roles" json:"users"`
+	Menus          []*Menu `gorm:"many2many:role_menus;" json:"menus"` // 角色菜单多对多关系
 }

--- a/public/common/validator.go
+++ b/public/common/validator.go
@@ -2,10 +2,18 @@ package common
 
 import (
 	"regexp"
+	"strings"
 
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+	"github.com/go-playground/locales/en"
+	"github.com/go-playground/locales/es"
+	"github.com/go-playground/locales/ja"
 	"github.com/go-playground/locales/zh"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
+	en_translations "github.com/go-playground/validator/v10/translations/en"
+	es_translations "github.com/go-playground/validator/v10/translations/es"
+	ja_translations "github.com/go-playground/validator/v10/translations/ja"
 	ch_translations "github.com/go-playground/validator/v10/translations/zh"
 )
 
@@ -15,16 +23,42 @@ var Validate *validator.Validate
 // 全局翻译器
 var Trans ut.Translator
 
+var TransByLocale map[string]ut.Translator
+
 // 初始化Validator数据校验
 func InitValidate() {
-	chinese := zh.New()
-	uni := ut.New(chinese, chinese)
-	trans, _ := uni.GetTranslator("zh")
-	Trans = trans
 	Validate = validator.New()
-	_ = ch_translations.RegisterDefaultTranslations(Validate, Trans)
+	TransByLocale = map[string]ut.Translator{}
+
+	chinese := zh.New()
+	english := en.New()
+	japanese := ja.New()
+	spanish := es.New()
+	uni := ut.New(chinese, chinese, english, japanese, spanish)
+
+	register := func(locale string, registerFn func(*validator.Validate, ut.Translator) error) {
+		trans, _ := uni.GetTranslator(locale)
+		_ = registerFn(Validate, trans)
+		TransByLocale[locale] = trans
+	}
+
+	register("zh", ch_translations.RegisterDefaultTranslations)
+	register("en", en_translations.RegisterDefaultTranslations)
+	register("ja", ja_translations.RegisterDefaultTranslations)
+	register("es", es_translations.RegisterDefaultTranslations)
+	TransByLocale["ko"] = TransByLocale["en"]
+
+	Trans = TransByLocale["zh"]
 	_ = Validate.RegisterValidation("checkMobile", checkMobile)
 	Log.Infof("初始化validator.v10数据校验器完成")
+}
+
+func TranslatorForLocale(locale string) ut.Translator {
+	lang := strings.Split(i18n.NormalizeLocale(locale), "-")[0]
+	if trans, ok := TransByLocale[lang]; ok {
+		return trans
+	}
+	return Trans
 }
 
 func checkMobile(fl validator.FieldLevel) bool {

--- a/public/i18n/i18n.go
+++ b/public/i18n/i18n.go
@@ -1,0 +1,251 @@
+package i18n
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ContextLocaleKey = "locale"
+	defaultLocale    = "zh-CN"
+)
+
+type Args map[string]any
+
+var (
+	mu               sync.RWMutex
+	activeDefault    = defaultLocale
+	supportedLocales = []string{"zh-CN", "en-US", "ja-JP", "es-ES", "ko-KR"}
+	messages         = map[string]map[string]string{}
+)
+
+func Init(defaultLoc string, supported []string) error {
+	SetSupportedLocales(supported, defaultLoc)
+
+	loaded := make(map[string]map[string]string)
+	for _, locale := range SupportedLocales() {
+		data, err := readLocaleFile(locale)
+		if err != nil {
+			return fmt.Errorf("read locale %s: %w", locale, err)
+		}
+		flat, err := flattenYAML(data)
+		if err != nil {
+			return fmt.Errorf("parse locale %s: %w", locale, err)
+		}
+		loaded[locale] = flat
+	}
+	SetMessages(loaded)
+	return nil
+}
+
+func readLocaleFile(locale string) ([]byte, error) {
+	filename := filepath.Join("locales", locale+".yaml")
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		candidate := filepath.Join(dir, filename)
+		if data, err := os.ReadFile(candidate); err == nil {
+			return data, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return nil, os.ErrNotExist
+}
+
+func SetSupportedLocales(locales []string, defaultLoc string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(locales) == 0 {
+		locales = []string{defaultLocale}
+	}
+	normalized := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		if norm := canonicalLocale(locale); norm != "" {
+			normalized = append(normalized, norm)
+		}
+	}
+	if len(normalized) == 0 {
+		normalized = []string{defaultLocale}
+	}
+	supportedLocales = dedupe(normalized)
+
+	defaultLoc = canonicalLocale(defaultLoc)
+	if !contains(supportedLocales, defaultLoc) {
+		defaultLoc = supportedLocales[0]
+	}
+	activeDefault = defaultLoc
+}
+
+func SupportedLocales() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	out := make([]string, len(supportedLocales))
+	copy(out, supportedLocales)
+	return out
+}
+
+func SetMessages(next map[string]map[string]string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	messages = next
+}
+
+func NormalizeLocale(raw string) string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	return normalizeLocaleLocked(raw)
+}
+
+func LocaleFromContext(c *gin.Context) string {
+	if c == nil {
+		return NormalizeLocale("")
+	}
+	if value, ok := c.Get(ContextLocaleKey); ok {
+		if locale, ok := value.(string); ok {
+			return NormalizeLocale(locale)
+		}
+	}
+	return NormalizeLocale("")
+}
+
+func SetLocale(c *gin.Context, locale string) {
+	c.Set(ContextLocaleKey, NormalizeLocale(locale))
+}
+
+func TC(c *gin.Context, key string, args Args) string {
+	return T(LocaleFromContext(c), key, args)
+}
+
+func T(locale string, key string, args Args) string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	locale = normalizeLocaleLocked(locale)
+	if msg := messages[locale][key]; msg != "" {
+		return format(msg, args)
+	}
+	if msg := messages[activeDefault][key]; msg != "" {
+		return format(msg, args)
+	}
+	if activeDefault != defaultLocale {
+		if msg := messages[defaultLocale][key]; msg != "" {
+			return format(msg, args)
+		}
+	}
+	return key
+}
+
+func normalizeLocaleLocked(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return activeDefault
+	}
+
+	for _, part := range strings.Split(raw, ",") {
+		token := strings.TrimSpace(strings.Split(part, ";")[0])
+		if token == "" {
+			continue
+		}
+		token = canonicalLocale(token)
+		if contains(supportedLocales, token) {
+			return token
+		}
+		lang := strings.Split(token, "-")[0]
+		for _, supported := range supportedLocales {
+			if strings.HasPrefix(supported, lang+"-") {
+				return supported
+			}
+		}
+	}
+	return activeDefault
+}
+
+func canonicalLocale(raw string) string {
+	raw = strings.TrimSpace(strings.ReplaceAll(raw, "_", "-"))
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "-")
+	if len(parts) == 1 {
+		return strings.ToLower(parts[0])
+	}
+	return strings.ToLower(parts[0]) + "-" + strings.ToUpper(parts[1])
+}
+
+func flattenYAML(data []byte) (map[string]string, error) {
+	var nested map[string]any
+	if err := yaml.Unmarshal(data, &nested); err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	flatten("", nested, out)
+	return out, nil
+}
+
+func flatten(prefix string, value any, out map[string]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			next := key
+			if prefix != "" {
+				next = prefix + "." + key
+			}
+			flatten(next, typed[key], out)
+		}
+	case string:
+		out[prefix] = typed
+	default:
+		out[prefix] = fmt.Sprint(typed)
+	}
+}
+
+func format(message string, args Args) string {
+	for key, value := range args {
+		message = strings.ReplaceAll(message, "{"+key+"}", fmt.Sprint(value))
+	}
+	return message
+}
+
+func contains(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupe(items []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}

--- a/public/i18n/i18n_test.go
+++ b/public/i18n/i18n_test.go
@@ -1,0 +1,80 @@
+package i18n
+
+import "testing"
+
+func TestNormalizeLocale(t *testing.T) {
+	SetSupportedLocales([]string{"zh-CN", "en-US", "ja-JP", "es-ES", "ko-KR"}, "zh-CN")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "exact", in: "en-US", want: "en-US"},
+		{name: "lower underscore", in: "en_us", want: "en-US"},
+		{name: "language family", in: "en-GB", want: "en-US"},
+		{name: "language only", in: "ja", want: "ja-JP"},
+		{name: "accept language", in: "es-MX,es;q=0.9,en;q=0.8", want: "es-ES"},
+		{name: "unknown", in: "it-IT", want: "zh-CN"},
+		{name: "empty", in: "", want: "zh-CN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeLocale(tt.in); got != tt.want {
+				t.Fatalf("NormalizeLocale(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslateWithArgsAndFallback(t *testing.T) {
+	SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	SetMessages(map[string]map[string]string{
+		"zh-CN": {
+			"common.success":     "成功",
+			"menu.create_failed": "创建菜单失败: {error}",
+		},
+		"en-US": {
+			"common.success":     "success",
+			"menu.create_failed": "failed to create menu: {error}",
+		},
+	})
+
+	if got := T("en-US", "common.success", nil); got != "success" {
+		t.Fatalf("T success = %q", got)
+	}
+	if got := T("en-US", "menu.create_failed", Args{"error": "duplicate"}); got != "failed to create menu: duplicate" {
+		t.Fatalf("T args = %q", got)
+	}
+	if got := T("en-US", "missing.key", nil); got != "missing.key" {
+		t.Fatalf("T missing = %q", got)
+	}
+	if got := T("en-GB", "common.success", nil); got != "success" {
+		t.Fatalf("T fallback locale = %q", got)
+	}
+}
+
+func TestEmailTemplatesLoadForAllLocales(t *testing.T) {
+	if err := Init("zh-CN", []string{"zh-CN", "en-US", "ja-JP", "es-ES", "ko-KR"}); err != nil {
+		t.Fatal(err)
+	}
+
+	keys := []string{
+		"email.password_reset_subject",
+		"email.password_reset_body",
+		"email.verification_code_subject",
+		"email.verification_code_body",
+		"email.user_creation_subject",
+		"email.user_creation_body",
+		"email.admin_password_reset_subject",
+		"email.admin_password_reset_body",
+	}
+	for _, locale := range SupportedLocales() {
+		for _, key := range keys {
+			if got := T(locale, key, nil); got == key || got == "" {
+				t.Fatalf("%s %s = %q", locale, key, got)
+			}
+		}
+	}
+}

--- a/public/i18n/keycheck_test.go
+++ b/public/i18n/keycheck_test.go
@@ -1,0 +1,133 @@
+package i18n
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestLocaleFilesHaveSameKeys(t *testing.T) {
+	if err := Init("zh-CN", []string{"zh-CN", "en-US", "ja-JP", "es-ES", "ko-KR"}); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.RLock()
+	defer mu.RUnlock()
+
+	base := messages["zh-CN"]
+	for locale, localeMessages := range messages {
+		if locale == "zh-CN" {
+			continue
+		}
+		for key := range base {
+			if _, ok := localeMessages[key]; !ok {
+				t.Fatalf("%s missing key %s", locale, key)
+			}
+		}
+		for key := range localeMessages {
+			if _, ok := base[key]; !ok {
+				t.Fatalf("%s has extra key %s", locale, key)
+			}
+		}
+	}
+}
+
+func TestMigratedBackendModulesDoNotUseChineseRawResponseErrors(t *testing.T) {
+	files := []string{
+		"logic/api_logic.go",
+		"logic/operation_log_logic.go",
+		"logic/field_relation_logic.go",
+		"logic/role_logic.go",
+		"logic/group_logic.go",
+		"logic/user_logic.go",
+		"logic/menu_logic.go",
+		"logic/base_logic.go",
+		"logic/dingtalk_logic.go",
+		"logic/feishu_logic.go",
+		"logic/wecom_logic.go",
+		"logic/openldap_logic.go",
+		"logic/a_logic.go",
+		"service/ildap/group_ildap.go",
+		"service/isql/api_isql.go",
+		"service/isql/role_isql.go",
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`New(Validator|MySql|Ldap|Operation)Error\(fmt\.Errorf\("[^"]*[\x{4e00}-\x{9fff}]`),
+		regexp.MustCompile(`return "[^"]*[\x{4e00}-\x{9fff}]`),
+	}
+	root := findRepoRoot(t)
+	for _, file := range files {
+		source, err := os.ReadFile(filepath.Join(root, file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pattern := range patterns {
+			if match := pattern.Find(source); match != nil {
+				t.Fatalf("%s contains raw Chinese response error: %s", file, string(match))
+			}
+		}
+	}
+}
+
+func TestServiceLayerErrorsThatReachResponsesDoNotUseChinese(t *testing.T) {
+	files := []string{
+		"service/isql/api_isql.go",
+		"service/isql/role_isql.go",
+		"service/ildap/group_ildap.go",
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`errors\.New\("[^"]*[\x{4e00}-\x{9fff}]`),
+		regexp.MustCompile(`fmt\.Errorf\("[^"]*[\x{4e00}-\x{9fff}]`),
+	}
+	root := findRepoRoot(t)
+	for _, file := range files {
+		source, err := os.ReadFile(filepath.Join(root, file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pattern := range patterns {
+			if match := pattern.Find(source); match != nil {
+				t.Fatalf("%s contains raw Chinese service error: %s", file, string(match))
+			}
+		}
+	}
+}
+
+func TestUserServiceChineseSentinelsAreLimitedToAuthMapping(t *testing.T) {
+	root := findRepoRoot(t)
+	source, err := os.ReadFile(filepath.Join(root, "service/isql/user_isql.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{
+		`errors.New("用户未登录")`: true,
+		`errors.New("用户不存在")`: true,
+		`errors.New("用户被禁用")`: true,
+		`errors.New("密码错误")`:  true,
+	}
+	pattern := regexp.MustCompile(`errors\.New\("[^"]*[\x{4e00}-\x{9fff}][^"]*"\)`)
+	for _, match := range pattern.FindAllString(string(source), -1) {
+		if !allowed[match] {
+			t.Fatalf("service/isql/user_isql.go contains unmapped Chinese sentinel: %s", match)
+		}
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}

--- a/public/tools/email.go
+++ b/public/tools/email.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/eryajf/go-ldap-admin/config"
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/patrickmn/go-cache"
 
 	"strconv"
@@ -37,78 +38,48 @@ func email(mailTo []string, subject string, body string) error {
 }
 
 func SendMail(sendto []string, pass string) error {
-	subject := "重置LDAP密码成功"
-	// 邮件正文
-	body := fmt.Sprintf("<li><a>更改之后的密码为: %s </a></li>", pass)
+	return SendMailI18n(sendto, pass, "")
+}
+
+func SendMailI18n(sendto []string, pass string, locale string) error {
+	subject := i18n.T(locale, "email.password_reset_subject", nil)
+	body := fmt.Sprintf(i18n.T(locale, "email.password_reset_body", nil), pass)
 	return email(sendto, subject, body)
 }
 
 // SendCode 发送验证码
 func SendCode(sendto []string) error {
+	return SendCodeI18n(sendto, "")
+}
+
+func SendCodeI18n(sendto []string, locale string) error {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	vcode := fmt.Sprintf("%06v", rnd.Int31n(1000000))
 	// 把验证码信息放到cache，以便于验证时拿到
 	VerificationCodeCache.Set(sendto[0], vcode, time.Minute*5)
-	subject := "验证码-重置密码"
-	//发送的内容
-	body := fmt.Sprintf(`<div>
-        <div>
-            尊敬的用户，您好！
-        </div>
-        <div style="padding: 8px 40px 8px 50px;">
-            <p>你本次的验证码为 %s ,为了保证账号安全，验证码有效期为5分钟。请确认为本人操作，切勿向他人泄露，感谢您的理解与使用。</p>
-        </div>
-        <div>
-            <p>此邮箱为系统邮箱，请勿回复。</p>
-        </div>
-    </div>`, vcode)
+	subject := i18n.T(locale, "email.verification_code_subject", nil)
+	body := fmt.Sprintf(i18n.T(locale, "email.verification_code_body", nil), vcode)
 	return email(sendto, subject, body)
 }
 
 // SendUserCreationNotification 发送用户创建成功通知邮件
 func SendUserCreationNotification(username, nickname, mail, password string) error {
-	subject := "LDAP账户创建成功通知"
-	// 邮件正文
-	body := fmt.Sprintf(`<div>
-        <div>
-            尊敬的%s，您好！
-        </div>
-        <div style="padding: 8px 40px 8px 50px;">
-            <p>您的LDAP账户已创建成功，以下是您的账户信息：</p>
-            <ul>
-                <li>用户名：%s</li>
-                <li>昵称：%s</li>
-                <li>初始密码：%s</li>
-            </ul>
-            <p style="color: #ff6600;">请妥善保管您的账户信息，建议首次登录后及时修改密码。</p>
-        </div>
-        <div>
-            <p>此邮箱为系统邮箱，请勿回复。</p>
-        </div>
-    </div>`, nickname, username, nickname, password)
+	return SendUserCreationNotificationI18n(username, nickname, mail, password, "")
+}
+
+func SendUserCreationNotificationI18n(username, nickname, mail, password string, locale string) error {
+	subject := i18n.T(locale, "email.user_creation_subject", nil)
+	body := fmt.Sprintf(i18n.T(locale, "email.user_creation_body", nil), nickname, username, nickname, password)
 	return email([]string{mail}, subject, body)
 }
 
 // SendPasswordResetNotification 发送密码重置成功通知邮件
 func SendPasswordResetNotification(username, nickname, mail, newPassword string) error {
-	subject := "LDAP密码重置成功通知"
-	// 邮件正文
-	body := fmt.Sprintf(`<div>
-        <div>
-            尊敬的%s，您好！
-        </div>
-        <div style="padding: 8px 40px 8px 50px;">
-            <p>您的LDAP账户密码已成功重置，以下是您的新密码信息：</p>
-            <ul>
-                <li>用户名：%s</li>
-                <li>新密码：%s</li>
-            </ul>
-            <p style="color: #ff6600;">为了您的账户安全，请尽快登录并修改为您自己的密码。</p>
-            <p style="color: #ff0000;">请妥善保管您的账户信息，切勿泄露给他人。</p>
-        </div>
-        <div>
-            <p>此邮箱为系统邮箱，请勿回复。</p>
-        </div>
-    </div>`, nickname, username, newPassword)
+	return SendPasswordResetNotificationI18n(username, nickname, mail, newPassword, "")
+}
+
+func SendPasswordResetNotificationI18n(username, nickname, mail, newPassword string, locale string) error {
+	subject := i18n.T(locale, "email.admin_password_reset_subject", nil)
+	body := fmt.Sprintf(i18n.T(locale, "email.admin_password_reset_body", nil), nickname, username, newPassword)
 	return email([]string{mail}, subject, body)
 }

--- a/public/tools/http.go
+++ b/public/tools/http.go
@@ -1,9 +1,12 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/eryajf/go-ldap-admin/public/i18n"
 	"github.com/gin-gonic/gin"
 )
 
@@ -16,8 +19,89 @@ const (
 )
 
 type RspError struct {
-	code int
-	err  error
+	code   int
+	err    error
+	msgKey string
+	args   i18n.Args
+}
+
+type legacyErrorKey struct {
+	raw    string
+	key    string
+	prefix bool
+}
+
+var legacyErrorKeys = []legacyErrorKey{
+	{raw: "获取当前登陆用户信息失败", key: "legacy.common.current_user_failed"},
+	{raw: "获取当前登陆用户失败", key: "legacy.common.current_user_failed"},
+	{raw: "获取资源列表失败: ", key: "legacy.common.resource_list_failed", prefix: true},
+	{raw: "该记录不存在", key: "legacy.common.record_not_found"},
+	{raw: "有用户不存在", key: "legacy.user.some_not_found"},
+	{raw: "该用户不存在", key: "legacy.user.not_found"},
+	{raw: "原密码错误", key: "legacy.user.old_password_incorrect"},
+	{raw: "原密码解析失败", key: "legacy.user.old_password_parse_failed"},
+	{raw: "新密码解析失败", key: "legacy.user.new_password_parse_failed"},
+	{raw: "用户已经是在职状态", key: "legacy.user.already_active"},
+	{raw: "用户已经是离职状态", key: "legacy.user.already_inactive"},
+	{raw: "只有管理员才能更改用户状态", key: "legacy.user.only_admin_change_status"},
+	{raw: "获取用户列表失败: ", key: "legacy.user.list_failed", prefix: true},
+	{raw: "获取用户总数失败", key: "legacy.user.count_failed"},
+	{raw: "添加用户失败", key: "legacy.user.create_failed", prefix: true},
+	{raw: "更新用户失败", key: "legacy.user.update_failed", prefix: true},
+	{raw: "获取用户信息失败: ", key: "legacy.user.info_failed", prefix: true},
+	{raw: "在LDAP删除用户失败", key: "legacy.user.ldap_delete_failed", prefix: true},
+	{raw: "在LDAP添加用户失败", key: "legacy.user.ldap_add_failed", prefix: true},
+	{raw: "在LDAP更新密码失败", key: "legacy.user.ldap_password_update_failed", prefix: true},
+	{raw: "在MySQL删除用户失败: ", key: "legacy.user.mysql_delete_failed", prefix: true},
+	{raw: "在MySQL更新密码失败: ", key: "legacy.user.mysql_password_update_failed", prefix: true},
+	{raw: "在MySQL更新用户状态失败: ", key: "legacy.user.mysql_status_update_failed", prefix: true},
+	{raw: "创建接口失败: ", key: "legacy.api.create_failed", prefix: true},
+	{raw: "获取接口列表失败: ", key: "legacy.api.list_failed", prefix: true},
+	{raw: "获取接口总数失败", key: "legacy.api.count_failed"},
+	{raw: "接口不存在", key: "legacy.api.not_found"},
+	{raw: "更新接口失败: ", key: "legacy.api.update_failed", prefix: true},
+	{raw: "删除接口失败: ", key: "legacy.api.delete_failed", prefix: true},
+	{raw: "该角色名已存在", key: "legacy.role.name_exists"},
+	{raw: "该角色名不已存在", key: "legacy.role.not_found"},
+	{raw: "获取当前用户最高角色等级失败: ", key: "legacy.role.current_max_sort_failed", prefix: true},
+	{raw: "当前用户没有权限更新角色", key: "legacy.role.no_update_permission"},
+	{raw: "不能创建比自己等级高或相同等级的角色", key: "legacy.role.cannot_create_higher_or_equal"},
+	{raw: "创建角色失败: ", key: "legacy.role.create_failed", prefix: true},
+	{raw: "获取菜单列表失败: ", key: "legacy.role.list_failed", prefix: true},
+	{raw: "获取角色信息失败: ", key: "legacy.role.info_failed", prefix: true},
+	{raw: "不能更新比自己角色等级高或相等的角色", key: "legacy.role.cannot_update_higher_or_equal"},
+	{raw: "不能把角色等级更新得比当前用户的等级高或相同", key: "legacy.role.cannot_set_higher_or_equal"},
+	{raw: "更新角色失败: ", key: "legacy.role.update_failed", prefix: true},
+	{raw: "未能获取到角色信息", key: "legacy.role.no_role_info"},
+	{raw: "不能删除比自己角色等级高或相等的角色", key: "legacy.role.cannot_delete_higher_or_equal"},
+	{raw: "删除角色失败: ", key: "legacy.role.delete_failed", prefix: true},
+	{raw: "获取角色的权限菜单失败: ", key: "legacy.role.menu_list_failed", prefix: true},
+	{raw: "获取父级组信息失败", key: "legacy.group.parent_info_failed"},
+	{raw: "该分组对应DN已存在", key: "legacy.group.dn_exists"},
+	{raw: "向LDAP创建分组失败", key: "legacy.group.ldap_create_failed", prefix: true},
+	{raw: "向MySQL创建分组失败", key: "legacy.group.mysql_create_failed"},
+	{raw: "添加用户到分组失败: ", key: "legacy.group.add_user_failed", prefix: true},
+	{raw: "获取分组列表失败: ", key: "legacy.group.list_failed", prefix: true},
+	{raw: "获取分组总数失败", key: "legacy.group.count_failed"},
+	{raw: "分组不存在", key: "legacy.group.not_found"},
+	{raw: "向LDAP更新分组失败：", key: "legacy.group.ldap_update_failed", prefix: true},
+	{raw: "向MySQL更新分组失败", key: "legacy.group.mysql_update_failed"},
+	{raw: "有分组不存在", key: "legacy.group.some_not_found"},
+	{raw: "存在子分组，请先删除子分组，再执行该分组的删除操作！", key: "legacy.group.has_children"},
+	{raw: "向LDAP删除分组失败：", key: "legacy.group.ldap_delete_failed", prefix: true},
+	{raw: "获取分组失败: ", key: "legacy.group.get_failed", prefix: true},
+	{raw: "ou类型的分组不能添加用户", key: "legacy.group.ou_cannot_add_user"},
+	{raw: "ou类型的分组内没有用户", key: "legacy.group.ou_has_no_user"},
+	{raw: "向LDAP添加用户到分组失败", key: "legacy.group.ldap_add_user_failed", prefix: true},
+	{raw: "处理用户的部门数据失败:", key: "legacy.group.user_department_failed", prefix: true},
+	{raw: "在MySQL更新用户失败：", key: "legacy.group.mysql_user_update_failed", prefix: true},
+	{raw: "将用户从ldap移除失败", key: "legacy.group.ldap_remove_user_failed", prefix: true},
+	{raw: "将用户从MySQL移除失败: ", key: "legacy.group.mysql_remove_user_failed", prefix: true},
+	{raw: "通过邮箱查询用户失败", key: "legacy.base.email_query_failed", prefix: true},
+	{raw: "LDAP生成新密码失败", key: "legacy.base.ldap_new_password_failed", prefix: true},
+	{raw: "获取角色总数失败", key: "legacy.role.count_failed"},
+	{raw: "获取菜单总数失败", key: "legacy.menu.count_failed"},
+	{raw: "获取日志总数失败", key: "legacy.log.count_failed"},
 }
 
 func (re *RspError) Error() string {
@@ -28,6 +112,14 @@ func (re *RspError) Code() int {
 	return re.code
 }
 
+func (re *RspError) MsgKey() string {
+	return re.msgKey
+}
+
+func (re *RspError) Args() i18n.Args {
+	return re.args
+}
+
 // NewRspError New
 func NewRspError(code int, err error) *RspError {
 	return &RspError{
@@ -36,9 +128,22 @@ func NewRspError(code int, err error) *RspError {
 	}
 }
 
+func NewRspI18nError(code int, msgKey string, args i18n.Args) *RspError {
+	return &RspError{
+		code:   code,
+		err:    errors.New(msgKey),
+		msgKey: msgKey,
+		args:   args,
+	}
+}
+
 // NewMySqlError mysql错误
 func NewMySqlError(err error) *RspError {
 	return NewRspError(MySqlErr, err)
+}
+
+func NewMySqlI18nError(msgKey string, args i18n.Args) *RspError {
+	return NewRspI18nError(MySqlErr, msgKey, args)
 }
 
 // NewValidatorError 验证错误
@@ -46,14 +151,26 @@ func NewValidatorError(err error) *RspError {
 	return NewRspError(ValidatorErr, err)
 }
 
+func NewValidatorI18nError(msgKey string, args i18n.Args) *RspError {
+	return NewRspI18nError(ValidatorErr, msgKey, args)
+}
+
 // NewLdapError ldap错误
 func NewLdapError(err error) *RspError {
 	return NewRspError(LdapErr, err)
 }
 
+func NewLdapI18nError(msgKey string, args i18n.Args) *RspError {
+	return NewRspI18nError(LdapErr, msgKey, args)
+}
+
 // NewOperationError 操作错误
 func NewOperationError(err error) *RspError {
 	return NewRspError(OperationErr, err)
+}
+
+func NewOperationI18nError(msgKey string, args i18n.Args) *RspError {
+	return NewRspI18nError(OperationErr, msgKey, args)
 }
 
 // ReloadErr 重新加载错误
@@ -77,20 +194,75 @@ func ReloadErr(err any) *RspError {
 
 // Success http 成功
 func Success(c *gin.Context, data any) {
+	SuccessI18n(c, data, "common.success", nil)
+}
+
+func SuccessI18n(c *gin.Context, data any, msgKey string, args i18n.Args) {
 	c.JSON(http.StatusOK, gin.H{
 		"code": 0,
-		"msg":  "success",
+		"msg":  i18n.TC(c, msgKey, args),
 		"data": data,
 	})
 }
 
 // Err http 错误
 func Err(c *gin.Context, err *RspError, data any) {
-	c.JSON(http.StatusOK, gin.H{
+	body := gin.H{
 		"code": err.Code(),
 		"msg":  err.Error(),
 		"data": data,
-	})
+	}
+	msgKey, args := err.MsgKey(), err.Args()
+	if msgKey == "" {
+		msgKey, args = lookupLegacyErrorKey(err.Error())
+	}
+	if msgKey == "" && i18n.LocaleFromContext(c) != i18n.NormalizeLocale("") && containsCJK(err.Error()) {
+		msgKey = fallbackErrorKey(err.Code())
+	}
+	if msgKey != "" {
+		body["msg"] = i18n.TC(c, msgKey, args)
+		body["msgKey"] = msgKey
+	}
+	c.JSON(http.StatusOK, body)
+}
+
+func lookupLegacyErrorKey(message string) (string, i18n.Args) {
+	for _, item := range legacyErrorKeys {
+		if item.prefix {
+			if strings.HasPrefix(message, item.raw) {
+				return item.key, i18n.Args{"error": strings.TrimPrefix(message, item.raw)}
+			}
+			continue
+		}
+		if message == item.raw {
+			return item.key, nil
+		}
+	}
+	return "", nil
+}
+
+func fallbackErrorKey(code int) string {
+	switch code {
+	case MySqlErr:
+		return "error.database"
+	case LdapErr:
+		return "error.ldap"
+	case OperationErr:
+		return "error.operation"
+	case ValidatorErr:
+		return "error.validator"
+	default:
+		return "common.unknown_error"
+	}
+}
+
+func containsCJK(message string) bool {
+	for _, r := range message {
+		if r >= '\u4e00' && r <= '\u9fff' {
+			return true
+		}
+	}
+	return false
 }
 
 // 返回前端

--- a/public/tools/http_test.go
+++ b/public/tools/http_test.go
@@ -1,0 +1,191 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eryajf/go-ldap-admin/public/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+func TestErrKeepsRawErrorCompatibility(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {"common.success": "success"},
+		"en-US": {"common.success": "success"},
+	})
+
+	r := gin.New()
+	r.GET("/err", func(c *gin.Context) {
+		Err(c, NewValidatorError(fmt.Errorf("用户名已存在")), nil)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/err", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["msg"] != "用户名已存在" {
+		t.Fatalf("msg = %#v", body["msg"])
+	}
+	if _, ok := body["msgKey"]; ok {
+		t.Fatalf("raw error should not include msgKey: %#v", body)
+	}
+}
+
+func TestErrLocalizesUnmappedChineseErrorForNonDefaultLocale(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {
+			"error.validator": "参数校验失败",
+		},
+		"en-US": {
+			"error.validator": "validation failed",
+		},
+	})
+
+	r := gin.New()
+	r.GET("/err", func(c *gin.Context) {
+		i18n.SetLocale(c, "en-US")
+		Err(c, NewValidatorError(fmt.Errorf("对应平台的动态字段关系已存在，请勿重复添加")), nil)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/err", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["msg"] != "validation failed" {
+		t.Fatalf("msg = %#v", body["msg"])
+	}
+	if body["msgKey"] != "error.validator" {
+		t.Fatalf("msgKey = %#v", body["msgKey"])
+	}
+}
+
+func TestErrLocalizesI18nError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {"user.username_exists": "用户名已存在"},
+		"en-US": {"user.username_exists": "username already exists"},
+	})
+
+	r := gin.New()
+	r.GET("/err", func(c *gin.Context) {
+		i18n.SetLocale(c, "en-US")
+		Err(c, NewValidatorI18nError("user.username_exists", nil), nil)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/err", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["msg"] != "username already exists" {
+		t.Fatalf("msg = %#v", body["msg"])
+	}
+	if body["msgKey"] != "user.username_exists" {
+		t.Fatalf("msgKey = %#v", body["msgKey"])
+	}
+}
+
+func TestErrLocalizesFieldRelationI18nError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {"field_relation.exists": "对应平台的动态字段关系已存在，请勿重复添加"},
+		"en-US": {"field_relation.exists": "the dynamic field relation for this platform already exists"},
+	})
+
+	r := gin.New()
+	r.GET("/err", func(c *gin.Context) {
+		i18n.SetLocale(c, "en-US")
+		Err(c, NewValidatorI18nError("field_relation.exists", nil), nil)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/err", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["msg"] != "the dynamic field relation for this platform already exists" {
+		t.Fatalf("msg = %#v", body["msg"])
+	}
+	if body["msgKey"] != "field_relation.exists" {
+		t.Fatalf("msgKey = %#v", body["msgKey"])
+	}
+}
+
+func TestErrLocalizesLegacyRawError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	i18n.SetSupportedLocales([]string{"zh-CN", "en-US"}, "zh-CN")
+	i18n.SetMessages(map[string]map[string]string{
+		"zh-CN": {
+			"legacy.common.current_user_failed": "获取当前登陆用户信息失败",
+			"legacy.api.create_failed":          "创建接口失败: {error}",
+		},
+		"en-US": {
+			"legacy.common.current_user_failed": "failed to get current login user information",
+			"legacy.api.create_failed":          "failed to create API: {error}",
+		},
+	})
+
+	r := gin.New()
+	r.GET("/exact", func(c *gin.Context) {
+		i18n.SetLocale(c, "en-US")
+		Err(c, NewMySqlError(fmt.Errorf("获取当前登陆用户信息失败")), nil)
+	})
+	r.GET("/prefix", func(c *gin.Context) {
+		i18n.SetLocale(c, "en-US")
+		Err(c, NewMySqlError(fmt.Errorf("创建接口失败: duplicate")), nil)
+	})
+
+	tests := []struct {
+		path       string
+		wantMsg    string
+		wantMsgKey string
+	}{
+		{
+			path:       "/exact",
+			wantMsg:    "failed to get current login user information",
+			wantMsgKey: "legacy.common.current_user_failed",
+		},
+		{
+			path:       "/prefix",
+			wantMsg:    "failed to create API: duplicate",
+			wantMsgKey: "legacy.api.create_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			var body map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if body["msg"] != tt.wantMsg {
+				t.Fatalf("msg = %#v", body["msg"])
+			}
+			if body["msgKey"] != tt.wantMsgKey {
+				t.Fatalf("msgKey = %#v", body["msgKey"])
+			}
+		})
+	}
+}

--- a/public/tools/rsa.go
+++ b/public/tools/rsa.go
@@ -16,20 +16,20 @@ func RSAEncrypt(data, publicBytes []byte) ([]byte, error) {
 	block, _ := pem.Decode(publicBytes)
 
 	if block == nil {
-		return res, fmt.Errorf("无法加密, 公钥可能不正确")
+		return res, fmt.Errorf("failed to encrypt: invalid public key")
 	}
 
 	// 使用X509将解码之后的数据 解析出来
 	// x509.MarshalPKCS1PublicKey(block):解析之后无法用，所以采用以下方法：ParsePKIXPublicKey
 	keyInit, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return res, fmt.Errorf("无法加密, 公钥可能不正确, %v", err)
+		return res, fmt.Errorf("failed to encrypt: invalid public key: %v", err)
 	}
 	// 使用公钥加密数据
 	pubKey := keyInit.(*rsa.PublicKey)
 	res, err = rsa.EncryptPKCS1v15(rand.Reader, pubKey, data)
 	if err != nil {
-		return res, fmt.Errorf("无法加密, 公钥可能不正确, %v", err)
+		return res, fmt.Errorf("failed to encrypt: invalid public key: %v", err)
 	}
 	// 将数据加密为base64格式
 	return []byte(EncodeStr2Base64(string(res))), nil
@@ -43,16 +43,16 @@ func RSADecrypt(base64Data, privateBytes []byte) ([]byte, error) {
 	// 解析私钥
 	block, _ := pem.Decode(privateBytes)
 	if block == nil {
-		return res, fmt.Errorf("无法解密, 私钥可能不正确,解析私钥失败")
+		return res, fmt.Errorf("failed to decrypt: invalid private key")
 	}
 	// 还原数据
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return res, fmt.Errorf("无法解密, 私钥可能不正确,解析PKCS失败 %v", err)
+		return res, fmt.Errorf("failed to decrypt: invalid private key: %v", err)
 	}
 	res, err = rsa.DecryptPKCS1v15(rand.Reader, privateKey, data)
 	if err != nil {
-		return res, fmt.Errorf("无法解密, 私钥可能不正确,解密PKCS1v15失败 %v", err)
+		return res, fmt.Errorf("failed to decrypt: invalid private key: %v", err)
 	}
 	return res, nil
 }

--- a/public/tools/util_test.go
+++ b/public/tools/util_test.go
@@ -2,10 +2,26 @@ package tools
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/eryajf/go-ldap-admin/config"
 )
 
 func TestGenPass(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+	config.InitConfig()
 	fmt.Printf("密码为：%s\n", NewGenPasswd("123456"))
 	// err := ComparePasswd("$2a$10$Fy8p0nCixgWKzLfO3SgdhOzAF7YolSt6dHj6QidDGYlzLJDpniXB6", "123456")
 	// if err != nil {

--- a/routes/a_routes.go
+++ b/routes/a_routes.go
@@ -37,6 +37,8 @@ func InitRoutes() *gin.Engine {
 		c.Data(http.StatusOK, "text/html; charset=utf-8", data)
 	})
 
+	r.Use(middleware.LocaleMiddleware())
+
 	// 启用限流中间件
 	// 默认每50毫秒填充一个令牌，最多填充200个
 	fillInterval := time.Duration(config.Conf.RateLimit.FillInterval)

--- a/service/ildap/group_ildap.go
+++ b/service/ildap/group_ildap.go
@@ -1,11 +1,10 @@
 package ildap
 
 import (
-	"errors"
-
 	"github.com/eryajf/go-ldap-admin/config"
 	"github.com/eryajf/go-ldap-admin/model"
 	"github.com/eryajf/go-ldap-admin/public/common"
+	"github.com/eryajf/go-ldap-admin/public/tools"
 
 	ldap "github.com/go-ldap/ldap/v3"
 )
@@ -83,7 +82,7 @@ func (x GroupService) Delete(gdn string) error {
 func (x GroupService) AddUserToGroup(dn, udn string) error {
 	//判断dn是否以ou开头
 	if dn[:3] == "ou=" {
-		return errors.New("不能添加用户到OU组织单元")
+		return tools.NewLdapI18nError("group.ou_cannot_add_user", nil)
 	}
 	newmr := ldap.NewModifyRequest(dn, nil)
 	newmr.Add("uniqueMember", []string{udn})

--- a/service/isql/api_isql.go
+++ b/service/isql/api_isql.go
@@ -67,7 +67,7 @@ func (s ApiService) Update(api *model.Api) error {
 	var oldApi model.Api
 	err := common.DB.First(&oldApi, api.ID).Error
 	if err != nil {
-		return errors.New("根据接口ID获取接口信息失败")
+		return errors.New("failed to get API information by API ID")
 	}
 	err = common.DB.Model(api).Where("id = ?", api.ID).Updates(api).Error
 	if err != nil {
@@ -81,7 +81,7 @@ func (s ApiService) Update(api *model.Api) error {
 			// 先删除
 			isRemoved, _ := common.CasbinEnforcer.RemovePolicies(policies)
 			if !isRemoved {
-				return errors.New("更新权限接口失败")
+				return errors.New("failed to update permission API")
 			}
 			for _, policy := range policies {
 				policy[1] = api.Path
@@ -90,12 +90,12 @@ func (s ApiService) Update(api *model.Api) error {
 			// 新增
 			isAdded, _ := common.CasbinEnforcer.AddPolicies(policies)
 			if !isAdded {
-				return errors.New("更新权限接口失败")
+				return errors.New("failed to update permission API")
 			}
 			// 加载policy
 			err := common.CasbinEnforcer.LoadPolicy()
 			if err != nil {
-				return errors.New("更新权限接口成功，权限接口策略加载失败")
+				return errors.New("permission API updated, but failed to load permission API policy")
 			} else {
 				return err
 			}
@@ -124,7 +124,7 @@ func (s ApiService) Delete(ids []uint) error {
 		api := new(model.Api)
 		err := s.Find(tools.H{"id": id}, api)
 		if err != nil {
-			return fmt.Errorf("根据ID获取接口信息失败: %v", err)
+			return fmt.Errorf("failed to get API information by ID: %v", err)
 		}
 		apis = append(apis, *api)
 	}
@@ -137,14 +137,14 @@ func (s ApiService) Delete(ids []uint) error {
 			if len(policies) > 0 {
 				isRemoved, _ := common.CasbinEnforcer.RemovePolicies(policies)
 				if !isRemoved {
-					return errors.New("删除权限接口失败")
+					return errors.New("failed to delete permission API")
 				}
 			}
 		}
 		// 重新加载策略
 		err := common.CasbinEnforcer.LoadPolicy()
 		if err != nil {
-			return errors.New("删除权限接口成功，权限接口策略加载失败")
+			return errors.New("permission API deleted, but failed to load permission API policy")
 		} else {
 			return err
 		}

--- a/service/isql/role_isql.go
+++ b/service/isql/role_isql.go
@@ -83,7 +83,7 @@ func (s RoleService) Delete(roleIds []uint) error {
 			if len(rmPolicies) > 0 {
 				isRemoved, _ := common.CasbinEnforcer.RemovePolicies(rmPolicies)
 				if !isRemoved {
-					return errors.New("删除角色成功, 删除角色关联权限接口失败")
+					return errors.New("role deleted, but failed to delete related permission APIs")
 				}
 			}
 		}
@@ -116,22 +116,22 @@ func (s RoleService) UpdateRoleApis(roleKeyword string, reqRolePolicies [][]stri
 	// 先获取path中的角色ID对应角色已有的police(需要先删除的)
 	err := common.CasbinEnforcer.LoadPolicy()
 	if err != nil {
-		return errors.New("角色的权限接口策略加载失败")
+		return errors.New("failed to load role permission API policy")
 	}
 	rmPolicies := common.CasbinEnforcer.GetFilteredPolicy(0, roleKeyword)
 	if len(rmPolicies) > 0 {
 		isRemoved, _ := common.CasbinEnforcer.RemovePolicies(rmPolicies)
 		if !isRemoved {
-			return errors.New("更新角色的权限接口失败")
+			return errors.New("failed to update role permission APIs")
 		}
 	}
 	isAdded, _ := common.CasbinEnforcer.AddPolicies(reqRolePolicies)
 	if !isAdded {
-		return errors.New("更新角色的权限接口失败")
+		return errors.New("failed to update role permission APIs")
 	}
 	err = common.CasbinEnforcer.LoadPolicy()
 	if err != nil {
-		return errors.New("更新角色的权限接口成功，角色的权限接口策略加载失败")
+		return errors.New("role permission APIs updated, but failed to load role permission API policy")
 	} else {
 		return err
 	}

--- a/service/isql/user_isql.go
+++ b/service/isql/user_isql.go
@@ -164,7 +164,7 @@ func (s UserService) GetUserMinRoleSortsByIds(ids []uint) ([]int, error) {
 		return []int{}, err
 	}
 	if len(userList) == 0 {
-		return []int{}, errors.New("未获取到任何用户信息")
+		return []int{}, errors.New("no user information found")
 	}
 	var roleMinSortList []int
 	for _, user := range userList {
@@ -210,7 +210,7 @@ func (s UserService) Delete(ids []uint) error {
 		user := new(model.User)
 		err := s.Find(filter, user)
 		if err != nil {
-			return fmt.Errorf("获取用户信息失败，err: %v", err)
+			return fmt.Errorf("failed to get user information: %v", err)
 		}
 		users = append(users, *user)
 	}
@@ -312,9 +312,6 @@ func (s UserService) Login(user *model.User) (*model.User, error) {
 	// 	Where("username = ?", user.Username).
 	// 	Preload("Roles").
 	// 	First(&firstUser).Error
-	// if err != nil {
-	// 	return nil, errors.New("用户不存在")
-	// }
 	err := s.Find(tools.H{"username": user.Username}, &firstUser)
 	if err != nil {
 		return nil, errors.New("用户不存在")
@@ -336,19 +333,10 @@ func (s UserService) Login(user *model.User) (*model.User, error) {
 	// 	}
 	// }
 
-	// if !isValidate {
-	// 	return nil, errors.New("用户角色被禁用")
-	// }
-
 	if tools.NewParPasswd(firstUser.Password) != user.Password {
 		return nil, errors.New("密码错误")
 	}
 
-	// 校验密码
-	// err = tools.ComparePasswd(firstUser.Password, user.Password)
-	// if err != nil {
-	// 	return &firstUser, errors.New("密码错误")
-	// }
 	return &firstUser, nil
 }
 


### PR DESCRIPTION
- 新增 i18n_test.go 和 keycheck_test.go 测试文件，确保国际化功能正常
- 更新邮件发送函数，支持多语言邮件内容
- 修改错误处理逻辑，使用国际化错误信息
- 更新多个服务文件中的错误信息为英文
- 添加中间件以支持请求的语言环境

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

/close #398

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [ ] 我已阅读并理解[贡献者指南](https://github.com/eryajf/go-ldap-admin/blob/main/CONTRIBUTING.md)。
- [ ] 我已检查没有与此请求重复的拉取请求。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**

-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加完整多语言支持：zh-CN、en-US、ja-JP、es-ES、ko-KR；启动时初始化 i18n。
  * 增加请求级语言中间件（X-Locale/Accept-Language）与自动语言检测。

* **改进**
  * 界面、菜单/角色/API 展示字段及系统提示均支持本地化显示。
  * 错误与响应本地化，响应中可返回 msgKey 以便前端展示。
  * 邮件/验证码/通知模板本地化。

* **测试**
  * 新增多项 i18n 与中间件相关自动化测试，校验语言文件一致性与翻译回退。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->