### PR TITLE
fix: 替换配置文件中的硬编码凭据为占位符

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -33,7 +33,7 @@ mysql:
   # 用户名
   username: root
   # 密码
-  password: 123456
+  password: your-password
   # 数据库名
   database: go_ldap_admin
   # 主机地址
@@ -56,7 +56,7 @@ jwt:
   # jwt标识
   realm: test jwt
   # 服务端密钥
-  key: secret key
+  key: your-jwt-key
   # token过期时间, 小时
   timeout: 12000
   # 刷新token最大过期时间, 小时
@@ -100,11 +100,11 @@ ldap:
   # ldap管理员DN
   admin-dn: "cn=admin,dc=eryajf,dc=net"
   # ldap管理员密码
-  admin-pass: "123456"
+  admin-pass: "your-ldap-password"
   # ldap用户OU
   user-dn: "ou=people,dc=eryajf,dc=net"
   # ldap用户初始默认密码
-  user-init-password: "123456"
+  user-init-password: "your-password"
   # 是否允许更改分组DN
   group-name-modify: false
   # 是否允许更改用户DN

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,10 @@ func InitConfig() {
 	if mysqlUsername != "" {
 		Conf.Mysql.Username = mysqlUsername
 	}
+	jwtKey := os.Getenv("JWT_KEY")
+	if jwtKey != "" {
+		Conf.Jwt.Key = jwtKey
+	}
 	mysqlPassword := os.Getenv("MYSQL_PASSWORD")
 	if mysqlPassword != "" {
 		Conf.Mysql.Password = mysqlPassword


### PR DESCRIPTION
## 问题

config.yml 中提交了 4 个硬编码凭据：

### 1. JWT 签名密钥 (CWE-798)

```yaml
# 修复前
jwt:
  key: secret key
```

AuthMiddleware.go:24 使用此密钥签发和验证 JWT token。任何人拿到源码即可伪造任意用户 token，绕过认证中间件。

### 2. MySQL 密码 (CWE-798)

```yaml
# 修复前
mysql:
  password: 123456
```

### 3. LDAP 管理员密码 (CWE-798)

```yaml
# 修复前
ldap:
  admin-pass: "123456"
```

### 4. LDAP 用户初始密码 (CWE-798)

```yaml
# 修复前
ldap:
  user-init-password: "123456"
```

## 修复

4 个硬编码值已替换为占位符。同时为 JWT 密钥添加了 `JWT_KEY` 环境变量支持（config.go），与已有的 MySQL/LDAP 环境变量覆盖机制保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 现在支持通过环境变量配置 JWT 密钥。

* **Chores**
  * 配置文件中的敏感凭据（数据库密码、JWT 密钥、LDAP 密码等）已更新为占位符，需要管理员在部署时根据实际环境进行配置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opsre/go-ldap-admin/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->